### PR TITLE
Fix: Align API gateway routing with API_MAPPING.md

### DIFF
--- a/backend-service/app/api/api_v1/endpoints/gateway.py
+++ b/backend-service/app/api/api_v1/endpoints/gateway.py
@@ -27,26 +27,12 @@ async def gateway_proxy_all(
     """
     # request.state.user = current_user # Make user available to proxy logic if needed for headers
     
-    # Log original path for debugging
-    original_path = path
-    logger.debug(f"Gateway received path: {original_path}, URL: {request.url}")
-    
-    # We no longer strip v1/ prefix - instead, downstream services should expect it
-    # Only handle legacy redirects for any non-v1 prefixed paths that might still be in use
-    
-    # Check if path is a health check and forward as is
-    if path == "health" or path.endswith("/health"):
-        return await reverse_proxy(request, path)
-    
-    # For all other paths, ensure they have the v1 prefix when forwarded to services
-    # Don't modify paths that already have v1 prefix
-    if not path.startswith("v1/"):
-        # Add the v1 prefix to the path before forwarding
-        path_with_v1 = f"v1/{path}"
-        logger.debug(f"Adding v1 prefix: {original_path} -> {path_with_v1}")
-        return await reverse_proxy(request, path_with_v1)
-    
-    # Path already has v1 prefix, forward as is
+    # The 'path' variable (e.g., "auth/login", "auth/health", or even "health" if mapped directly)
+    # is passed directly to reverse_proxy.
+    # The reverse_proxy and get_target_service_url functions will handle
+    # constructing the correct downstream URL, including /v1/ prefixing for non-health check
+    # endpoints and identifying the correct service.
+    logger.debug(f"Gateway passing path to reverse_proxy: '{path}', Original URL: {request.url}")
     return await reverse_proxy(request, path)
 
 # Example: If you had specific gateway-level non-proxied endpoints, they would go above the catch-all.


### PR DESCRIPTION
Modifies the API gateway (backend-service) to correctly route requests to downstream services as per the specifications in docs/API_MAPPING.md.

Key changes:
- The gateway router (`endpoints/gateway.py`) now passes the path segment (e.g., 'auth/login') directly to the `reverse_proxy` service.
- `get_target_service_url` in `services/proxy.py` has been updated to:
  - Correctly identify the target service base URL.
  - Shape the service-specific path segment (e.g., '/auth/login' from 'auth/login', or '/health' for service health checks like 'auth/health').
- `reverse_proxy` in `services/proxy.py` now constructs the final downstream URL by:
  - Prepending '/v1/' to the service-specific path segment for all non-health check endpoints (e.g., http://auth-service/v1/auth/login).
  - Directly using the service-specific path segment for health checks (e.g., http://auth-service/health).