### PR TITLE
Implement Trust Score data collection and calculation

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -138,7 +138,7 @@
 ### 2.2 Trust & Access Control Service (`services/trust_access_control_service/`)
 
 - [x] **T-2.2.1** — Scaffold trust_access_control_service
-- [/] **T-2.2.2** — Implement Trust Score calculation engine (Partial: uses mock data)
+- [x] **T-2.2.2** — Implement Trust Score calculation engine (Uses real graph data)
 - [x] **T-2.2.3** — Implement trust score storage
 - [x] **T-2.2.4** — Implement trust HTTP endpoints
 - [x] **T-2.2.5** — Write Dockerfile + add to `docker-compose.yml`
@@ -146,7 +146,7 @@
 ### 2.3 Relationship Verification Service (`services/relationship_verification_service/`)
 
 - [x] **T-2.3.1** — Scaffold relationship_verification_service
-- [/] **T-2.3.2** — Implement Suggestion model and workflow (Partial: simplified logic)
+- [x] **T-2.3.2** — Implement Suggestion model and workflow (Syncs to Neo4j)
 - [x] **T-2.3.3** — Implement verification HTTP endpoints
 - [x] **T-2.3.4** — Write Dockerfile + add to `docker-compose.yml`
 

--- a/services/genealogy_service/internal/handlers/genealogy_handler.go
+++ b/services/genealogy_service/internal/handlers/genealogy_handler.go
@@ -25,7 +25,11 @@ func (h *GenealogyHandler) CreateTree(c *gin.Context) {
 		response.Error(c, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	ownerID, _ := uuid.Parse(ownerIDStr.(string))
+	ownerID, err := uuid.Parse(ownerIDStr.(string))
+	if err != nil {
+		response.Error(c, http.StatusUnauthorized, "invalid user id")
+		return
+	}
 
 	var req models.CreateTreeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -58,7 +62,11 @@ func (h *GenealogyHandler) ListUserTrees(c *gin.Context) {
 		response.Error(c, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	ownerID, _ := uuid.Parse(ownerIDStr.(string))
+	ownerID, err := uuid.Parse(ownerIDStr.(string))
+	if err != nil {
+		response.Error(c, http.StatusUnauthorized, "invalid user id")
+		return
+	}
 
 	trees, err := h.svc.ListUserTrees(c.Request.Context(), ownerID)
 	if err != nil {
@@ -69,13 +77,24 @@ func (h *GenealogyHandler) ListUserTrees(c *gin.Context) {
 }
 
 func (h *GenealogyHandler) AddPerson(c *gin.Context) {
+	ownerIDStr, exists := c.Get(auth.UserIDKey)
+	if !exists {
+		response.Error(c, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	ownerID, err := uuid.Parse(ownerIDStr.(string))
+	if err != nil {
+		response.Error(c, http.StatusUnauthorized, "invalid user id")
+		return
+	}
+
 	var req models.CreatePersonRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		response.Error(c, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	person, err := h.svc.AddPerson(c.Request.Context(), req)
+	person, err := h.svc.AddPerson(c.Request.Context(), ownerID, req)
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, err.Error())
 		return
@@ -100,6 +119,17 @@ func (h *GenealogyHandler) GetPerson(c *gin.Context) {
 }
 
 func (h *GenealogyHandler) UpdatePerson(c *gin.Context) {
+	ownerIDStr, exists := c.Get(auth.UserIDKey)
+	if !exists {
+		response.Error(c, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	ownerID, err := uuid.Parse(ownerIDStr.(string))
+	if err != nil {
+		response.Error(c, http.StatusUnauthorized, "invalid user id")
+		return
+	}
+
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		response.Error(c, http.StatusBadRequest, "invalid ID")
@@ -112,7 +142,7 @@ func (h *GenealogyHandler) UpdatePerson(c *gin.Context) {
 		return
 	}
 
-	person, err := h.svc.UpdatePerson(c.Request.Context(), id, req)
+	person, err := h.svc.UpdatePerson(c.Request.Context(), id, ownerID, req)
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, err.Error())
 		return

--- a/services/genealogy_service/internal/models/models.go
+++ b/services/genealogy_service/internal/models/models.go
@@ -26,6 +26,7 @@ type Person struct {
 	Facts              []Fact                 `json:"facts"`
 	DNATests           []DNATest              `json:"dna_tests"`
 	TreeID             string                 `json:"tree_id"`
+	CreatedBy          uuid.UUID              `json:"created_by"`
 	CreatedAt          time.Time              `json:"created_at"`
 	UpdatedAt          time.Time              `json:"updated_at"`
 }

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -141,11 +141,15 @@ func (r *neo4jRepository) CreatePerson(ctx context.Context, person *models.Perso
 				clan: $clan,
 				tribe: $tribe,
 				created_at: $created_at,
-				updated_at: $updated_at
+				updated_at: $updated_at,
+				created_by: $created_by
 			})
 			WITH p
 			MATCH (t:FamilyTree {id: $tree_id})
 			CREATE (p)-[:MEMBER_OF]->(t)
+			WITH p
+			MERGE (u:User {id: $created_by})
+			CREATE (u)-[:CREATED]->(p)
 			RETURN p
 		`
 		params := map[string]interface{}{
@@ -162,6 +166,7 @@ func (r *neo4jRepository) CreatePerson(ctx context.Context, person *models.Perso
 			"created_at":        person.CreatedAt.Format(time.RFC3339),
 			"updated_at":        person.UpdatedAt.Format(time.RFC3339),
 			"tree_id":           person.TreeID,
+			"created_by":        person.CreatedBy.String(),
 		}
 		_, err := tx.Run(ctx, query, params)
 		return nil, err
@@ -186,6 +191,11 @@ func (r *neo4jRepository) GetPersonByID(ctx context.Context, id uuid.UUID) (*mod
 			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
 			updatedAt, _ := time.Parse(time.RFC3339, props["updated_at"].(string))
 
+			var createdBy uuid.UUID
+			if cb, ok := props["created_by"].(string); ok {
+				createdBy, _ = uuid.Parse(cb)
+			}
+
 			return &models.Person{
 				ID: id,
 				PrimaryName: models.Name{
@@ -200,6 +210,7 @@ func (r *neo4jRepository) GetPersonByID(ctx context.Context, id uuid.UUID) (*mod
 				Clan:            props["clan"].(string),
 				Tribe:           props["tribe"].(string),
 				TreeID:          treeID,
+				CreatedBy:       createdBy,
 				CreatedAt:       createdAt,
 				UpdatedAt:       updatedAt,
 			}, nil
@@ -215,7 +226,7 @@ func (r *neo4jRepository) GetPersonByID(ctx context.Context, id uuid.UUID) (*mod
 	return result.(*models.Person), nil
 }
 
-func (r *neo4jRepository) UpdatePerson(ctx context.Context, person *models.Person) error {
+func (r *neo4jRepository) UpdatePerson(ctx context.Context, person *models.Person, userID uuid.UUID) error {
 	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close(ctx)
 
@@ -232,6 +243,9 @@ func (r *neo4jRepository) UpdatePerson(ctx context.Context, person *models.Perso
 				p.clan = $clan,
 				p.tribe = $tribe,
 				p.updated_at = $updated_at
+			WITH p
+			MERGE (u:User {id: $user_id})
+			MERGE (u)-[:UPDATED]->(p)
 			RETURN p
 		`
 		params := map[string]interface{}{
@@ -246,6 +260,7 @@ func (r *neo4jRepository) UpdatePerson(ctx context.Context, person *models.Perso
 			"clan":              person.Clan,
 			"tribe":             person.Tribe,
 			"updated_at":        person.UpdatedAt.Format(time.RFC3339),
+			"user_id":           userID.String(),
 		}
 		_, err := tx.Run(ctx, query, params)
 		return nil, err

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -16,7 +16,7 @@ type Repository interface {
 	// Person operations
 	CreatePerson(ctx context.Context, person *models.Person) error
 	GetPersonByID(ctx context.Context, id uuid.UUID) (*models.Person, error)
-	UpdatePerson(ctx context.Context, person *models.Person) error
+	UpdatePerson(ctx context.Context, person *models.Person, userID uuid.UUID) error
 	DeletePerson(ctx context.Context, id uuid.UUID) error
 	ListPersonsByTree(ctx context.Context, treeID string) ([]models.Person, error)
 

--- a/services/genealogy_service/internal/service/genealogy_service.go
+++ b/services/genealogy_service/internal/service/genealogy_service.go
@@ -65,7 +65,7 @@ func (s *genealogyService) ListUserTrees(ctx context.Context, ownerID uuid.UUID)
 	return s.repo.ListTreesByOwner(ctx, ownerID)
 }
 
-func (s *genealogyService) AddPerson(ctx context.Context, req models.CreatePersonRequest) (*models.Person, error) {
+func (s *genealogyService) AddPerson(ctx context.Context, userID uuid.UUID, req models.CreatePersonRequest) (*models.Person, error) {
 	person := &models.Person{
 		ID:                uuid.New(),
 		PrimaryName:       req.PrimaryName,
@@ -78,6 +78,7 @@ func (s *genealogyService) AddPerson(ctx context.Context, req models.CreatePerso
 		Tribe:             req.Tribe,
 		TraditionalTitles: req.TraditionalTitles,
 		TreeID:            req.TreeID,
+		CreatedBy:         userID,
 		CreatedAt:         time.Now(),
 		UpdatedAt:         time.Now(),
 	}
@@ -109,7 +110,7 @@ func (s *genealogyService) GetPerson(ctx context.Context, id uuid.UUID) (*models
 	return person, nil
 }
 
-func (s *genealogyService) UpdatePerson(ctx context.Context, id uuid.UUID, req models.CreatePersonRequest) (*models.Person, error) {
+func (s *genealogyService) UpdatePerson(ctx context.Context, id, userID uuid.UUID, req models.CreatePersonRequest) (*models.Person, error) {
 	person, err := s.repo.GetPersonByID(ctx, id)
 	if err != nil {
 		return nil, err
@@ -129,7 +130,7 @@ func (s *genealogyService) UpdatePerson(ctx context.Context, id uuid.UUID, req m
 	person.TraditionalTitles = req.TraditionalTitles
 	person.UpdatedAt = time.Now()
 
-	if err := s.repo.UpdatePerson(ctx, person); err != nil {
+	if err := s.repo.UpdatePerson(ctx, person, userID); err != nil {
 		return nil, err
 	}
 

--- a/services/genealogy_service/internal/service/service.go
+++ b/services/genealogy_service/internal/service/service.go
@@ -14,9 +14,9 @@ type Service interface {
 	ListUserTrees(ctx context.Context, ownerID uuid.UUID) ([]models.FamilyTree, error)
 
 	// Person management
-	AddPerson(ctx context.Context, req models.CreatePersonRequest) (*models.Person, error)
+	AddPerson(ctx context.Context, userID uuid.UUID, req models.CreatePersonRequest) (*models.Person, error)
 	GetPerson(ctx context.Context, id uuid.UUID) (*models.Person, error)
-	UpdatePerson(ctx context.Context, id uuid.UUID, req models.CreatePersonRequest) (*models.Person, error)
+	UpdatePerson(ctx context.Context, id, userID uuid.UUID, req models.CreatePersonRequest) (*models.Person, error)
 	DeletePerson(ctx context.Context, id uuid.UUID) error
 	ListTreePersons(ctx context.Context, treeID string) ([]models.Person, error)
 

--- a/services/relationship_verification_service/cmd/main.go
+++ b/services/relationship_verification_service/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/chifamba/dzinza/services/relationship_verification_service/internal/repository"
 	"github.com/chifamba/dzinza/services/relationship_verification_service/internal/service"
 	"github.com/gin-gonic/gin"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -41,6 +43,15 @@ func main() {
 	// Auto-migrate
 	db.AutoMigrate(&models.Suggestion{})
 
+	// Initialize Neo4j
+	ctx := context.Background()
+	neo4jDriver, err := neo4j.NewDriverWithContext(cfg.Neo4jURI, neo4j.BasicAuth(cfg.Neo4jUser, cfg.Neo4jPassword, ""))
+	if err != nil {
+		logger.Error("Failed to connect to Neo4j", "error", err)
+		os.Exit(1)
+	}
+	defer neo4jDriver.Close(ctx)
+
 	// Initialize Redis and Event Bus
 	redisClient := redis.NewClient(&redis.Options{
 		Addr:     fmt.Sprintf("%s:%d", cfg.RedisHost, cfg.RedisPort),
@@ -49,8 +60,9 @@ func main() {
 	eventBus := events.NewRedisBus(redisClient)
 
 	// Setup layers
-	repo := repository.NewPostgresRepository(db)
-	verifySvc := service.NewVerificationService(repo, eventBus)
+	pgRepo := repository.NewPostgresRepository(db)
+	neoRepo := repository.NewNeo4jRepository(neo4jDriver)
+	verifySvc := service.NewVerificationService(pgRepo, neoRepo, eventBus)
 	verifyHandler := handlers.NewVerificationHandler(verifySvc)
 
 	r := gin.Default()

--- a/services/relationship_verification_service/go.mod
+++ b/services/relationship_verification_service/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
@@ -39,6 +40,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/neo4j/neo4j-go-driver/v5 v5.28.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect

--- a/services/relationship_verification_service/go.sum
+++ b/services/relationship_verification_service/go.sum
@@ -42,6 +42,8 @@ github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -70,6 +72,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OH
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/neo4j/neo4j-go-driver/v5 v5.28.4 h1:7toxehVcYkZbyxV4W3Ib9VcnyRBQPucF+VwNNmtSXi4=
+github.com/neo4j/neo4j-go-driver/v5 v5.28.4/go.mod h1:Vff8OwT7QpLm7L2yYr85XNWe9Rbqlbeb9asNXJTHO4k=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/services/relationship_verification_service/internal/repository/neo4j_repository.go
+++ b/services/relationship_verification_service/internal/repository/neo4j_repository.go
@@ -1,0 +1,76 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/chifamba/dzinza/services/relationship_verification_service/internal/models"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+type neo4jRepo struct {
+	driver neo4j.DriverWithContext
+}
+
+// NewNeo4jRepository creates a new instance of Neo4j repository for verification.
+func NewNeo4jRepository(driver neo4j.DriverWithContext) Neo4jRepository {
+	return &neo4jRepo{driver: driver}
+}
+
+func (r *neo4jRepo) CreateSuggestionNode(ctx context.Context, suggestion *models.Suggestion) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MERGE (u:User {id: $proposer_id})
+			CREATE (s:Suggestion {
+				id: $id,
+				type: $type,
+				target_id: $target_id,
+				status: $status,
+				created_at: $created_at
+			})
+			CREATE (u)-[:PROPOSED]->(s)
+			RETURN s
+		`
+		params := map[string]interface{}{
+			"proposer_id": suggestion.ProposerID,
+			"id":          suggestion.ID,
+			"type":        suggestion.Type,
+			"target_id":   suggestion.TargetID,
+			"status":      string(suggestion.Status),
+			"created_at":  suggestion.CreatedAt.Format(time.RFC3339),
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}
+
+func (r *neo4jRepo) UpdateSuggestionStatus(ctx context.Context, suggestionID string, status models.SuggestionStatus, verifierID string) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		// Update status
+		query := `
+			MATCH (s:Suggestion {id: $id})
+			SET s.status = $status,
+				s.updated_at = $updated_at
+			WITH s
+			MERGE (v:User {id: $verifier_id})
+			MERGE (v)-[:VERIFIED]->(s)
+			RETURN s
+		`
+		params := map[string]interface{}{
+			"id":          suggestionID,
+			"status":      string(status),
+			"updated_at":  time.Now().Format(time.RFC3339),
+			"verifier_id": verifierID,
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}

--- a/services/relationship_verification_service/internal/repository/postgres_repository.go
+++ b/services/relationship_verification_service/internal/repository/postgres_repository.go
@@ -7,13 +7,6 @@ import (
 	"gorm.io/gorm"
 )
 
-type VerificationRepository interface {
-	CreateSuggestion(ctx context.Context, suggestion *models.Suggestion) error
-	GetSuggestionByID(ctx context.Context, id string) (*models.Suggestion, error)
-	UpdateSuggestion(ctx context.Context, suggestion *models.Suggestion) error
-	ListPendingSuggestions(ctx context.Context) ([]models.Suggestion, error)
-}
-
 type postgresRepo struct {
 	db *gorm.DB
 }

--- a/services/relationship_verification_service/internal/repository/repository.go
+++ b/services/relationship_verification_service/internal/repository/repository.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/chifamba/dzinza/services/relationship_verification_service/internal/models"
+)
+
+type VerificationRepository interface {
+	CreateSuggestion(ctx context.Context, suggestion *models.Suggestion) error
+	GetSuggestionByID(ctx context.Context, id string) (*models.Suggestion, error)
+	UpdateSuggestion(ctx context.Context, suggestion *models.Suggestion) error
+	ListPendingSuggestions(ctx context.Context) ([]models.Suggestion, error)
+}
+
+type Neo4jRepository interface {
+	CreateSuggestionNode(ctx context.Context, suggestion *models.Suggestion) error
+	UpdateSuggestionStatus(ctx context.Context, suggestionID string, status models.SuggestionStatus, verifierID string) error
+}

--- a/services/relationship_verification_service/internal/service/verification_service.go
+++ b/services/relationship_verification_service/internal/service/verification_service.go
@@ -32,16 +32,18 @@ type Config struct {
 
 type verificationService struct {
 	repo       repository.VerificationRepository
+	neo4jRepo  repository.Neo4jRepository
 	eventBus   events.Bus
 	httpClient *http.Client
 	config     Config
 }
 
 // NewVerificationService creates a verification service with event bus and trust score integration.
-func NewVerificationService(repo repository.VerificationRepository, eventBus events.Bus) VerificationService {
+func NewVerificationService(repo repository.VerificationRepository, neo4jRepo repository.Neo4jRepository, eventBus events.Bus) VerificationService {
 	return &verificationService{
-		repo:     repo,
-		eventBus: eventBus,
+		repo:       repo,
+		neo4jRepo:  neo4jRepo,
+		eventBus:   eventBus,
 		httpClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
@@ -93,6 +95,14 @@ func (s *verificationService) ProposeChange(ctx context.Context, proposerID, tar
 
 	if err := s.repo.CreateSuggestion(ctx, suggestion); err != nil {
 		return nil, fmt.Errorf("failed to create suggestion: %w", err)
+	}
+
+	if err := s.neo4jRepo.CreateSuggestionNode(ctx, suggestion); err != nil {
+		// Log error but don't fail, to avoid inconsistency with Postgres (unless we rollback)
+		slog.Error("failed to create suggestion in neo4j", slog.Any("error", err))
+		// For consistency, returning error might be better, but we already committed to Postgres.
+		// A proper distributed transaction or saga pattern is needed here.
+		// For now, let's log and proceed.
 	}
 
 	return suggestion, nil
@@ -175,6 +185,10 @@ func (s *verificationService) VerifySuggestion(ctx context.Context, verifierID, 
 
 	if err := s.repo.UpdateSuggestion(ctx, suggestion); err != nil {
 		return fmt.Errorf("failed to update suggestion: %w", err)
+	}
+
+	if err := s.neo4jRepo.UpdateSuggestionStatus(ctx, suggestion.ID, suggestion.Status, verifierID); err != nil {
+		slog.Error("failed to update suggestion status in neo4j", slog.Any("error", err))
 	}
 
 	// Publish event if suggestion reached a final state

--- a/services/trust_access_control_service/internal/repository/trust_repository.go
+++ b/services/trust_access_control_service/internal/repository/trust_repository.go
@@ -55,17 +55,17 @@ func (r *trustRepo) GetTrustScore(ctx context.Context, userID string) (*models.T
 			node := res.Record().Values[0].(neo4j.Node)
 			props := node.Props
 
-			score, _ := props["trust_score"].(float64)
-			acceptedContribs, _ := props["accepted_contributions"].(int64)
-			rejectionRate, _ := props["rejection_rate"].(float64)
-			accountDays, _ := props["account_longevity_days"].(int64)
+			score := floatFromNeo4j(props["trust_score"])
+			acceptedContribs := intFromNeo4j(props["accepted_contributions"])
+			rejectionRate := floatFromNeo4j(props["rejection_rate"])
+			accountDays := intFromNeo4j(props["account_longevity_days"])
 
 			return &models.TrustScore{
 				UserID:                userID,
 				Score:                 score,
-				AcceptedContributions: int(acceptedContribs),
+				AcceptedContributions: acceptedContribs,
 				RejectionRate:         rejectionRate,
-				AccountLongevityDays:  int(accountDays),
+				AccountLongevityDays:  accountDays,
 			}, nil
 		}
 		return nil, nil
@@ -141,15 +141,12 @@ func (r *trustRepo) GetUserActivityStats(ctx context.Context, userID string) (*m
 			OPTIONAL MATCH (u)-[:PROPOSED]->(s:Suggestion)
 			WITH u,
 				 COUNT(CASE WHEN s.status = 'CONFIRMED' THEN 1 END) AS accepted,
-				 COUNT(CASE WHEN s.status = 'REJECTED' THEN 1 END) AS rejected,
-				 COUNT(CASE WHEN s.status IS NOT NULL THEN 1 END) AS total_suggestions
+				 COUNT(CASE WHEN s.status = 'REJECTED' THEN 1 END) AS rejected
 			OPTIONAL MATCH (u)-[:VERIFIED]->(v:Suggestion)
-			WITH u, accepted, rejected, total_suggestions,
-				 COUNT(v) AS verifications
+			WITH u, accepted, rejected, COUNT(v) AS verifications
 			OPTIONAL MATCH (u)-[:CREATED|UPDATED]->(p:Person)
 			WHERE p.updated_at > datetime() - duration({days: 30})
-			WITH u, accepted, rejected, verifications,
-				 COUNT(p) AS recent_activity
+			WITH u, accepted, rejected, verifications, COUNT(p) AS recent_activity
 			RETURN accepted, rejected, verifications, recent_activity
 		`
 		res, err := tx.Run(ctx, query, map[string]interface{}{"id": userID})
@@ -184,6 +181,9 @@ func (r *trustRepo) GetUserActivityStats(ctx context.Context, userID string) (*m
 
 // intFromNeo4j safely converts a Neo4j value to int.
 func intFromNeo4j(val interface{}) int {
+	if val == nil {
+		return 0
+	}
 	switch v := val.(type) {
 	case int64:
 		return int(v)
@@ -193,5 +193,22 @@ func intFromNeo4j(val interface{}) int {
 		return v
 	default:
 		return 0
+	}
+}
+
+// floatFromNeo4j safely converts a Neo4j value to float64.
+func floatFromNeo4j(val interface{}) float64 {
+	if val == nil {
+		return 0.0
+	}
+	switch v := val.(type) {
+	case float64:
+		return v
+	case int64:
+		return float64(v)
+	case int:
+		return float64(v)
+	default:
+		return 0.0
 	}
 }


### PR DESCRIPTION
Implemented the core logic for Trust Score calculation by ensuring all user activities (creating/updating persons, proposing/verifying suggestions) are recorded in the Neo4j graph.

Key changes:
1.  **Genealogy Service**:
    *   Added `CreatedBy` to `Person` model.
    *   Updated `AddPerson` and `UpdatePerson` to capture `userID` from context.
    *   Updated Neo4j repository to create `(User)-[:CREATED]->(Person)` and `(User)-[:UPDATED]->(Person)` relationships.

2.  **Relationship Verification Service**:
    *   Added `neo4j-go-driver` dependency.
    *   Implemented `Neo4jRepository` to mirror Suggestions to Neo4j.
    *   Updated `ProposeChange` to create `(User)-[:PROPOSED]->(Suggestion)` in Neo4j.
    *   Updated `VerifySuggestion` to create `(User)-[:VERIFIED]->(Suggestion)` in Neo4j.

3.  **Trust Access Control Service**:
    *   Updated `GetUserActivityStats` query to correctly aggregate stats from `PROPOSED`, `VERIFIED`, and `CREATED|UPDATED` relationships.
    *   Added helper functions for safe type assertion of Neo4j properties.

This closes the loop for Trust Score calculation, allowing `trust_access_control_service` to compute scores based on real user contributions.

---
*PR created automatically by Jules for task [4138797742279468980](https://jules.google.com/task/4138797742279468980) started by @chifamba*