### PR TITLE
Implement DNA & Integration API Stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 
@@ -249,7 +249,7 @@
 
 ### 4.4 External Integrations
 
-- [ ] **T-4.4.1** — Implement generic integration service (Stubbed)
+- [x] **T-4.4.1** — Implement generic integration service (Stubbed)
 
 ### 4.5 Production Readiness
 

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -1,7 +1,11 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/models"
@@ -38,6 +42,33 @@ func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]mod
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
+	// Send request to integration service
+	payload := map[string]interface{}{
+		"provider": "Ancestry", // In a real implementation, determine provider from testID
+		"config":   map[string]string{},
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sync payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "http://integration_service:8017/api/v1/integration/sync", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create sync request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call integration service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("integration service returned error status: %d", resp.StatusCode)
+	}
+
 	return nil
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/models"
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/repository"
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/service"
+	"github.com/chifamba/dzinza/services/pkg/events"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -33,7 +34,7 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 
 	// 1. Start Neo4j Container
 	neo4jContainer, err := neo4jcontainer.RunContainer(ctx,
-		testcontainers.WithImage("neo4j:2026.01.4"),
+		testcontainers.WithImage("neo4j:5.26"),
 		neo4jcontainer.WithAdminPassword("testpassword"),
 	)
 	require.NoError(t, err)
@@ -54,7 +55,12 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	// 3. Setup App
 	jwtSecret := "test-secret"
 	repo := repository.NewNeo4jRepository(driver)
-	svc := service.NewGenealogyService(repo)
+
+	// Use mock bus
+	mockBus := &mockEventBus{
+		published: make(map[events.EventType][]interface{}),
+	}
+	svc := service.NewGenealogyService(repo, mockBus)
 	handler := handlers.NewGenealogyHandler(svc)
 
 	gin.SetMode(gin.TestMode)
@@ -144,6 +150,19 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusConflict, w.Code) // Should fail due to circular ref
 	})
+}
+
+type mockEventBus struct {
+	published map[events.EventType][]interface{}
+}
+
+func (m *mockEventBus) Publish(ctx context.Context, topic events.EventType, payload interface{}) error {
+	m.published[topic] = append(m.published[topic], payload)
+	return nil
+}
+
+func (m *mockEventBus) Subscribe(ctx context.Context, topic events.EventType) (<-chan string, error) {
+	return make(<-chan string), nil
 }
 
 func TestMain(m *testing.M) {

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -201,11 +201,33 @@ func (p *ancestryProvider) Name() string { return "Ancestry" }
 
 func (p *ancestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("Ancestry: fetching data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{
+				"type":       "genealogy_person",
+				"first_name": "John",
+				"last_name":  "Doe",
+				"birth_year": 1900,
+				"birth_place": "London",
+			},
+		},
+	}, nil
 }
 
 func (p *ancestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"first_name":  raw["first_name"],
+				"last_name":   raw["last_name"],
+				"birth_year":  raw["birth_year"],
+				"birth_place": raw["birth_place"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // dna23AndMeProvider is a stub for 23andMe DNA provider.


### PR DESCRIPTION
Implement tasks from todo.md:
- T-4.1.2: Implement DNA provider API stubs
- T-4.4.1: Implement generic integration service stubs
- Fix genealogy_service integration tests by supplying mock bus and fixing neo4j image version.

---
*PR created automatically by Jules for task [14679746203944876363](https://jules.google.com/task/14679746203944876363) started by @chifamba*