### PR TITLE
feat(deduplication): implement topology similarity using Jaccard index

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -153,7 +153,7 @@
 ### 2.4 Deduplication Service (`services/deduplication_service/`)
 
 - [x] **T-2.4.1** — Scaffold deduplication_service
-- [/] **T-2.4.2** — Implement duplicate detection algorithm (Partial: basic exact match)
+- [x] **T-2.4.2** — Implement duplicate detection algorithm
 - [x] **T-2.4.3** — Implement merge logic
 - [x] **T-2.4.4** — Implement deduplication HTTP endpoints
 - [x] **T-2.4.5** — Write Dockerfile + add to `docker-compose.yml`

--- a/services/deduplication_service/internal/models/deduplication.go
+++ b/services/deduplication_service/internal/models/deduplication.go
@@ -6,11 +6,12 @@ import "time"
 type DuplicatePair struct {
 	Person1ID       string    `json:"person1_id"`
 	Person2ID       string    `json:"person2_id"`
-	ConfidenceScore float64   `json:"confidence_score"`
-	NameSimilarity  float64   `json:"name_similarity"`
-	DateSimilarity  float64   `json:"date_similarity"`
-	PlaceSimilarity float64   `json:"place_similarity"`
-	Status          string    `json:"status"` // PENDING, IGNORED, MERGED
+	ConfidenceScore    float64   `json:"confidence_score"`
+	NameSimilarity     float64   `json:"name_similarity"`
+	DateSimilarity     float64   `json:"date_similarity"`
+	PlaceSimilarity    float64   `json:"place_similarity"`
+	TopologySimilarity float64   `json:"topology_similarity"`
+	Status             string    `json:"status"` // PENDING, IGNORED, MERGED
 	DetectedAt      time.Time `json:"detected_at"`
 }
 

--- a/services/deduplication_service/internal/service/deduplication_service.go
+++ b/services/deduplication_service/internal/service/deduplication_service.go
@@ -59,18 +59,33 @@ func (s *deduplicationService) DetectDuplicates(ctx context.Context) ([]models.D
 				nameSim := NameSimilarityScore(p1.GivenName, p1.Surname, p2.GivenName, p2.Surname)
 				dateSim := DateProximityScore(p1.BirthDate, p2.BirthDate)
 				placeSim := PlaceSimilarityScore(p1.BirthPlace, p2.BirthPlace)
-				confidence := ComputeConfidenceScore(nameSim, dateSim, placeSim)
+
+				preliminaryScore := nameSim*40.0 + dateSim*20.0 + placeSim*15.0
+				var topologySim float64
+
+				if preliminaryScore > 30.0 {
+					rel1, err1 := s.repo.GetPersonRelatives(ctx, p1.ID)
+					rel2, err2 := s.repo.GetPersonRelatives(ctx, p2.ID)
+					if err1 == nil && err2 == nil {
+						topologySim = TopologySimilarityScore(rel1, rel2)
+					} else {
+						slog.Warn("dedup: failed to fetch relatives for topology comparison", slog.Any("err1", err1), slog.Any("err2", err2))
+					}
+				}
+
+				confidence := ComputeConfidenceScore(nameSim, dateSim, placeSim, topologySim)
 
 				if confidence >= s.confidenceThreshold {
 					pairs = append(pairs, models.DuplicatePair{
-						Person1ID:       p1.ID,
-						Person2ID:       p2.ID,
-						ConfidenceScore: confidence,
-						NameSimilarity:  nameSim,
-						DateSimilarity:  dateSim,
-						PlaceSimilarity: placeSim,
-						Status:          "PENDING",
-						DetectedAt:      time.Now(),
+						Person1ID:          p1.ID,
+						Person2ID:          p2.ID,
+						ConfidenceScore:    confidence,
+						NameSimilarity:     nameSim,
+						DateSimilarity:     dateSim,
+						PlaceSimilarity:    placeSim,
+						TopologySimilarity: topologySim,
+						Status:             "PENDING",
+						DetectedAt:         time.Now(),
 					})
 				}
 			}

--- a/services/deduplication_service/internal/service/similarity.go
+++ b/services/deduplication_service/internal/service/similarity.go
@@ -157,14 +157,45 @@ func PlaceSimilarityScore(place1, place2 string) float64 {
 // ComputeConfidenceScore computes an overall duplicate confidence score (0–100).
 //
 // Weights:
-//   - Name similarity: 50%
-//   - Date proximity: 30%
-//   - Place similarity: 20%
-func ComputeConfidenceScore(nameSimilarity, dateSimilarity, placeSimilarity float64) float64 {
-	score := nameSimilarity*50.0 + dateSimilarity*30.0 + placeSimilarity*20.0
+//   - Name similarity: 40%
+//   - Date proximity: 20%
+//   - Place similarity: 15%
+//   - Topology similarity: 25%
+func ComputeConfidenceScore(nameSimilarity, dateSimilarity, placeSimilarity, topologySimilarity float64) float64 {
+	score := nameSimilarity*40.0 + dateSimilarity*20.0 + placeSimilarity*15.0 + topologySimilarity*25.0
 
 	// Round to 2 decimal places
 	return math.Round(score*100) / 100
+}
+
+// TopologySimilarityScore computes the Jaccard index (intersection over union) of shared relatives.
+// Returns 0.0-1.0 where 1.0 means all relatives match.
+func TopologySimilarityScore(relatives1, relatives2 []string) float64 {
+	if len(relatives1) == 0 && len(relatives2) == 0 {
+		return 0.0 // Neutral score if both have no relatives
+	}
+
+	set := make(map[string]bool)
+	intersection := 0
+
+	for _, rel := range relatives1 {
+		set[rel] = true
+	}
+
+	for _, rel := range relatives2 {
+		if set[rel] {
+			intersection++
+		} else {
+			set[rel] = true
+		}
+	}
+
+	union := len(set)
+	if union == 0 {
+		return 0.0
+	}
+
+	return float64(intersection) / float64(union)
 }
 
 func min(a, b, c int) int {

--- a/services/deduplication_service/internal/service/similarity_test.go
+++ b/services/deduplication_service/internal/service/similarity_test.go
@@ -99,19 +99,20 @@ func TestNameSimilarityScore(t *testing.T) {
 
 func TestComputeConfidenceScore(t *testing.T) {
 	tests := []struct {
-		name   string
-		nameSim, dateSim, placeSim float64
-		expected float64
+		name                                 string
+		nameSim, dateSim, placeSim, topoSim  float64
+		expected                             float64
 	}{
-		{"perfect match", 1.0, 1.0, 1.0, 100.0},
-		{"no match", 0.0, 0.0, 0.0, 0.0},
-		{"name only", 1.0, 0.0, 0.0, 50.0},
-		{"name + date", 1.0, 1.0, 0.0, 80.0},
+		{"perfect match", 1.0, 1.0, 1.0, 1.0, 100.0},
+		{"no match", 0.0, 0.0, 0.0, 0.0, 0.0},
+		{"name only", 1.0, 0.0, 0.0, 0.0, 40.0},
+		{"name + date", 1.0, 1.0, 0.0, 0.0, 60.0},
+		{"name + date + place", 1.0, 1.0, 1.0, 0.0, 75.0},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			score := ComputeConfidenceScore(tc.nameSim, tc.dateSim, tc.placeSim)
+			score := ComputeConfidenceScore(tc.nameSim, tc.dateSim, tc.placeSim, tc.topoSim)
 			if math.Abs(score-tc.expected) > 0.01 {
 				t.Errorf("ComputeConfidenceScore = %.2f, want %.2f", score, tc.expected)
 			}


### PR DESCRIPTION
- Implemented `TopologySimilarityScore` using the Jaccard index (intersection over union).
- Updated `ComputeConfidenceScore` to include topology similarity with the weighting: Name (40%), Date (20%), Place (15%), and Topology (25%).
- Updated `DetectDuplicates` to compute a preliminary score and fetch relatives if it exceeds 30.0.
- Added `TopologySimilarity` to the `DuplicatePair` model.
- Marked T-2.4.2 as complete in `todo.md`.
- Updated test cases in `similarity_test.go` to reflect the new confidence score logic.

---
*PR created automatically by Jules for task [12374386712613000943](https://jules.google.com/task/12374386712613000943) started by @chifamba*