### PR TITLE
Implement DNA provider API stubs (T-4.1.2)

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -1,7 +1,12 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/models"
@@ -38,6 +43,38 @@ func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]mod
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
+	slog.Info("syncing DNA test with provider", slog.String("test_id", testID.String()))
+
+	// Note: in a real implementation we would look up the DNA test provider from the DB first.
+	// For now, we simulate calling the integration service with a default provider.
+	payload := map[string]interface{}{
+		"provider": "23andMe",
+		"config":   map[string]string{"access_token": "dummy-token"},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal integration request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://integration_service:8017/api/v1/integration/sync", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create integration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Error("failed to call integration service", slog.Any("error", err))
+		return fmt.Errorf("failed to call integration service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("integration service returned status: %d", resp.StatusCode)
+	}
+
+	slog.Info("successfully synced DNA test with provider", slog.String("test_id", testID.String()))
 	return nil
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/models"
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/repository"
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/service"
+	"github.com/chifamba/dzinza/services/pkg/events"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -24,6 +25,20 @@ import (
 	neo4jcontainer "github.com/testcontainers/testcontainers-go/modules/neo4j"
 )
 
+type mockEventBus struct {
+	Published []events.EventType
+}
+
+func (m *mockEventBus) Publish(ctx context.Context, topic events.EventType, payload interface{}) error {
+	m.Published = append(m.Published, topic)
+	return nil
+}
+func (m *mockEventBus) Subscribe(ctx context.Context, topic events.EventType) (<-chan string, error) {
+	ch := make(chan string)
+	return ch, nil
+}
+func (m *mockEventBus) Close() error { return nil }
+
 func TestGenealogyServiceIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -33,7 +48,7 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 
 	// 1. Start Neo4j Container
 	neo4jContainer, err := neo4jcontainer.RunContainer(ctx,
-		testcontainers.WithImage("neo4j:2026.01.4"),
+		testcontainers.WithImage("neo4j:5.12"),
 		neo4jcontainer.WithAdminPassword("testpassword"),
 	)
 	require.NoError(t, err)
@@ -54,7 +69,9 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	// 3. Setup App
 	jwtSecret := "test-secret"
 	repo := repository.NewNeo4jRepository(driver)
-	svc := service.NewGenealogyService(repo)
+	// "Integration tests for the genealogy_service utilize a custom mock event bus implementing the events.Bus interface (Publish, Subscribe) to simulate event publishing, as events.MockBus is not provided in the standard pkg/events package."
+	mockBus := &mockEventBus{}
+	svc := service.NewGenealogyService(repo, mockBus)
 	handler := handlers.NewGenealogyHandler(svc)
 
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
Implemented the `SyncWithProvider` logic inside the `genealogy_service` so that it calls the `integration_service` api instead of just being an empty method stub. Also updated the Master Task List `todo.md` to properly check off task T-4.1.2 as done, and fixed integration test compilation issues for local tests.

---
*PR created automatically by Jules for task [11418398506035077798](https://jules.google.com/task/11418398506035077798) started by @chifamba*