### PR TITLE
🧹 Remove unused import: Fact

### DIFF
--- a/services/genealogy_service/handlers.py
+++ b/services/genealogy_service/handlers.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, status, Depends, UploadFile, File,
 import jwt
 from config import JWT_SECRET
 from uuid import uuid4
-from schemas import FamilyTreeCreate, FamilyTree, PersonCreate, Person, Relationship, RelationshipType, RelationshipEvent, Fact, DNAData, HistoricalRecord
+from schemas import FamilyTreeCreate, FamilyTree, PersonCreate, Person, Relationship, RelationshipType, RelationshipEvent, DNAData, HistoricalRecord
 from typing import List, Any
 from fastapi import Response
 from models import get_neo4j_driver


### PR DESCRIPTION
This change removes an unused import of the `Fact` class in `services/genealogy_service/handlers.py`.

🎯 **What:** The code health issue addressed was an unused import.
💡 **Why:** Removing unused imports cleans up the code, improves readability, and avoids potential confusion.
✅ **Verification:** 
- Confirmed `Fact` is not used in the file except in Cypher queries/comments.
- Ran `python3 -m py_compile` to ensure no syntax errors.
- Code review approved.
✨ **Result:** A cleaner `handlers.py` file for the genealogy service.

---
*PR created automatically by Jules for task [1988299306750083954](https://jules.google.com/task/1988299306750083954) started by @chifamba*