### PR TITLE
🧹 Remove unused HTTPException import in audit_history_service

### DIFF
--- a/services/audit_history_service/handlers.py
+++ b/services/audit_history_service/handlers.py
@@ -1,6 +1,6 @@
 """Handlers for Audit History Service."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from sqlalchemy.orm import Session
 from .models import AuditLog
 from pydantic import BaseModel


### PR DESCRIPTION
🎯 **What:** Removed the unused `HTTPException` import from `services/audit_history_service/handlers.py`.
💡 **Why:** This code health improvement cleans up the module's namespace and removes unnecessary dependencies, slightly improving readability and load times without affecting the service's functionality.
✅ **Verification:** Verified the change by confirming syntax validity with `python3 -m py_compile` and ensuring that all automated tests passed via `pytest services/audit_history_service/`.
✨ **Result:** A cleaner and more maintainable handlers module in the audit history service.

---
*PR created automatically by Jules for task [6855289271588026309](https://jules.google.com/task/6855289271588026309) started by @chifamba*