### PR TITLE
🧹 Code Health: Remove unused Request import in Notification Service

### DIFF
--- a/services/notification_service/handlers.py
+++ b/services/notification_service/handlers.py
@@ -1,6 +1,6 @@
 """Handlers for Notification Service."""
 
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Request
+from fastapi import APIRouter, HTTPException, BackgroundTasks
 import time
 from collections import deque
 from pydantic import BaseModel, EmailStr


### PR DESCRIPTION
🎯 **What:** Removed unused `Request` import from `services/notification_service/handlers.py`.
💡 **Why:** The `Request` class was imported from `fastapi` but never used in the handlers module. Removing it cleans up the file and slightly improves load times, leading to better code maintainability.
✅ **Verification:**
- Ran `python3 -m py_compile services/notification_service/handlers.py` to ensure no syntax errors.
- Ran `pytest` on the `services/notification_service/` to ensure no test failures were introduced (0 tests ran, but no syntax/import errors caused failures).
- Requested a code review which passed cleanly with no regressions found.
✨ **Result:** Improved codebase cleanliness by adhering to standard Python linting practices and removing dead code.

---
*PR created automatically by Jules for task [18267900500650807941](https://jules.google.com/task/18267900500650807941) started by @chifamba*