### PR TITLE
🧹 refactor(genealogy_service): remove unused Field import from schemas

### DIFF
--- a/services/genealogy_service/schemas.py
+++ b/services/genealogy_service/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for genealogy_service service."""
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, HttpUrl
 from typing import List, Optional, Any
 from uuid import UUID
 from enum import Enum


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`Field` from `pydantic`) in `services/genealogy_service/schemas.py`.
💡 **Why:** Unused imports can be safely removed to clean up the code and slightly improve load times.
✅ **Verification:** Ran pytest tests for `genealogy_service` to confirm nothing broke.
✨ **Result:** A slightly cleaner file with no behavioral change.

---
*PR created automatically by Jules for task [13190374577748270042](https://jules.google.com/task/13190374577748270042) started by @chifamba*