### PR TITLE
🧹 Remove unused uuid import from help_support_service handlers

### DIFF
--- a/services/help_support_service/handlers.py
+++ b/services/help_support_service/handlers.py
@@ -12,7 +12,6 @@ from schemas import (
     ForumPostCreate, ForumPost, ForumReplyCreate, ForumReply
 )
 from models import ticket_model, chat_model, knowledge_base_model
-import uuid
 from datetime import datetime
 
 router = APIRouter()


### PR DESCRIPTION
🎯 **What:** Removed the unused `import uuid` statement from `services/help_support_service/handlers.py`.
💡 **Why:** Unused imports clutter the codebase and slightly increase load times. Removing it improves code maintainability and readability.
✅ **Verification:** Verified syntax correctness using `python3 -m py_compile` and ran the pytest test suite to ensure no regressions.
✨ **Result:** Cleaned up handlers.py without affecting existing functionality.

---
*PR created automatically by Jules for task [12545844020353050752](https://jules.google.com/task/12545844020353050752) started by @chifamba*