### PR TITLE
🧹 Remove unused Dict import in community_marketplace_service handlers

### DIFF
--- a/services/community_marketplace_service/handlers.py
+++ b/services/community_marketplace_service/handlers.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, HTTPException, UploadFile, File
 from pydantic import BaseModel
-from typing import List, Dict, Optional
+from typing import List, Optional
 
 router = APIRouter()
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `Dict` import from the `typing` module on line 5 of `services/community_marketplace_service/handlers.py`.
💡 **Why:** `Dict` was imported but never utilized within the module. Removing it improves code cleanliness and maintainability, resolving a minor code health issue.
✅ **Verification:**
1. Ran `python3 -m py_compile services/community_marketplace_service/handlers.py` to confirm there are no syntax errors.
2. Ran pytest in the service directory (`pytest services/community_marketplace_service`) which successfully executed.
3. Code review verified that this change does not introduce any logic modifications or bugs, as it purely cleans up imports.
✨ **Result:** A cleaner `handlers.py` file without dead code imports.

---
*PR created automatically by Jules for task [5760250263845797370](https://jules.google.com/task/5760250263845797370) started by @chifamba*