### PR TITLE
🧹 Refactor unused imports in help_support_service handlers

### DIFF
--- a/services/help_support_service/handlers.py
+++ b/services/help_support_service/handlers.py
@@ -8,8 +8,7 @@ from typing import List, Optional
 from schemas import (
     TicketCreate, TicketUpdate, Ticket, MessageCreate, Message,
     ChatSessionCreate, ChatSession, ChatMessage,
-    KnowledgeBaseCreate, KnowledgeBaseUpdate, KnowledgeBase,
-    ForumPostCreate, ForumPost, ForumReplyCreate, ForumReply
+    KnowledgeBaseCreate, KnowledgeBase
 )
 from models import ticket_model, chat_model, knowledge_base_model
 import uuid


### PR DESCRIPTION
🎯 **What:** Removed unused schemas (`KnowledgeBaseUpdate`, `ForumPostCreate`, `ForumPost`, `ForumReplyCreate`, `ForumReply`) imported from `schemas` in `services/help_support_service/handlers.py`.
💡 **Why:** These schemas were being imported but not used anywhere in the handlers. Removing them cleans up the file, reduces load time, and improves maintainability.
✅ **Verification:**
1. Ran `python3 -m py_compile services/help_support_service/handlers.py` to ensure valid Python syntax.
2. Verified through `grep` that none of these specific schemas were used elsewhere in the file.
3. Attempted to run tests using `pytest` (0 collected items as the service doesn't have local tests).
✨ **Result:** A cleaner `handlers.py` file without unused imports.

---
*PR created automatically by Jules for task [14089025197597848005](https://jules.google.com/task/14089025197597848005) started by @chifamba*