### PR TITLE
🧹 Remove unused forum schema imports in help_support_service

### DIFF
--- a/services/help_support_service/handlers.py
+++ b/services/help_support_service/handlers.py
@@ -8,8 +8,7 @@ from typing import List, Optional
 from schemas import (
     TicketCreate, TicketUpdate, Ticket, MessageCreate, Message,
     ChatSessionCreate, ChatSession, ChatMessage,
-    KnowledgeBaseCreate, KnowledgeBaseUpdate, KnowledgeBase,
-    ForumPostCreate, ForumPost, ForumReplyCreate, ForumReply
+    KnowledgeBaseCreate, KnowledgeBase
 )
 from models import ticket_model, chat_model, knowledge_base_model
 import uuid


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`KnowledgeBaseUpdate`, `ForumPostCreate`, `ForumPost`, `ForumReplyCreate`, `ForumReply`) from the `schemas` import block in `services/help_support_service/handlers.py`.
💡 **Why:** These schemas were imported but never used in the handlers file, likely because the community forums feature is currently just a placeholder implementation that doesn't use actual schema models. Removing dead code improves code maintainability and readability.
✅ **Verification:** Verified by running the syntax check (`python3 -m py_compile services/help_support_service/handlers.py`) and confirming that pytest executes without errors (0 tests collected, 0 errors).
✨ **Result:** A cleaner import section without affecting any existing functionality.

---
*PR created automatically by Jules for task [14125899718559678977](https://jules.google.com/task/14125899718559678977) started by @chifamba*