### PR TITLE
🧹 Remove unused Optional import in trust_access_control_service

### DIFF
--- a/services/trust_access_control_service/handlers.py
+++ b/services/trust_access_control_service/handlers.py
@@ -1,7 +1,7 @@
 """Request handlers for trust_access_control_service service."""
 
 from fastapi import APIRouter
-from typing import Dict, Optional
+from typing import Dict
 
 router = APIRouter()
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `Optional` import from the `typing` module in `services/trust_access_control_service/handlers.py`.
💡 **Why:** The `Optional` import was not being used anywhere in the file. Removing unused imports cleans up the code, reduces clutter, and slightly improves load times, thereby improving maintainability and readability.
✅ **Verification:** Ran `python3 -m py_compile services/trust_access_control_service/handlers.py` to ensure the syntax remains valid and no regressions were introduced. Also requested a code review which passed correctly.
✨ **Result:** The codebase is cleaner and follows better code health practices without changing any functionality.

---
*PR created automatically by Jules for task [17566548161620228552](https://jules.google.com/task/17566548161620228552) started by @chifamba*