### PR TITLE
🧹 Code Health: Remove unused KnowledgeBaseUpdate import in help_support_service

### DIFF
--- a/services/help_support_service/handlers.py
+++ b/services/help_support_service/handlers.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from schemas import (
     TicketCreate, TicketUpdate, Ticket, MessageCreate, Message,
     ChatSessionCreate, ChatSession, ChatMessage,
-    KnowledgeBaseCreate, KnowledgeBaseUpdate, KnowledgeBase,
+    KnowledgeBaseCreate, KnowledgeBase,
     ForumPostCreate, ForumPost, ForumReplyCreate, ForumReply
 )
 from models import ticket_model, chat_model, knowledge_base_model


### PR DESCRIPTION
🎯 **What:** Removed the unused `KnowledgeBaseUpdate` import from `services/help_support_service/handlers.py`.
💡 **Why:** To improve code maintainability by eliminating dead code.
✅ **Verification:** Verified code syntax with `python -m py_compile` and manually confirmed via `grep` that `KnowledgeBaseUpdate` is not referenced anywhere else in `handlers.py`.
✨ **Result:** A cleaner import block without changing the runtime behavior of the service.

---
*PR created automatically by Jules for task [12064876009159374928](https://jules.google.com/task/12064876009159374928) started by @chifamba*