### PR TITLE
🧹 Remove unused imports in help_support_service/handlers.py

### DIFF
--- a/services/help_support_service/handlers.py
+++ b/services/help_support_service/handlers.py
@@ -8,11 +8,9 @@ from typing import List, Optional
 from schemas import (
     TicketCreate, TicketUpdate, Ticket, MessageCreate, Message,
     ChatSessionCreate, ChatSession, ChatMessage,
-    KnowledgeBaseCreate, KnowledgeBaseUpdate, KnowledgeBase,
-    ForumPostCreate, ForumPost, ForumReplyCreate, ForumReply
+    KnowledgeBaseCreate, KnowledgeBase
 )
 from models import ticket_model, chat_model, knowledge_base_model
-import uuid
 from datetime import datetime
 
 router = APIRouter()


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`ForumPostCreate`, `KnowledgeBaseUpdate`, `ForumPost`, `ForumReplyCreate`, `ForumReply`, and `uuid`) from `services/help_support_service/handlers.py`.
💡 **Why:** To improve code maintainability, cleanliness, and potentially reduce module load times, addressing the code health issue.
✅ **Verification:** Verified syntax using `python3 -m py_compile`, verified clean output via `flake8`, and verified that tests don't break (no test regressions).
✨ **Result:** A cleaner import block without unused dependencies.

---
*PR created automatically by Jules for task [15492830350497684823](https://jules.google.com/task/15492830350497684823) started by @chifamba*