### PR TITLE
🧹 [media_storage_service] Remove unused subprocess import

### DIFF
--- a/services/media_storage_service/handlers.py
+++ b/services/media_storage_service/handlers.py
@@ -9,7 +9,6 @@ from .metadata import (
 )
 from .exif_utils import extract_exif
 from .image_utils import compress_image, generate_thumbnail
-import subprocess
 
 router = APIRouter()
 


### PR DESCRIPTION
🎯 **What:** Removed an unused `import subprocess` from `services/media_storage_service/handlers.py`.
💡 **Why:** To improve code health, reduce potential clutter, and slightly improve readability by removing a dependency import that is not needed in the current module's execution flow.
✅ **Verification:** Verified that `handlers.py` compiles correctly without syntax errors using `python3 -m py_compile services/media_storage_service/handlers.py` and that `pytest services/media_storage_service/` completes successfully (though no tests currently exist for this service).
✨ **Result:** Cleaned up the module's imports without changing any functionality.

---
*PR created automatically by Jules for task [15655434703213933297](https://jules.google.com/task/15655434703213933297) started by @chifamba*