### PR TITLE
🧹 [Code Health] Remove unused `List` import in relationship_verification_service/handlers.py

### DIFF
--- a/services/relationship_verification_service/handlers.py
+++ b/services/relationship_verification_service/handlers.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, UploadFile, File
 from pydantic import BaseModel
-from typing import Optional, List
+from typing import Optional
 
 router = APIRouter()
 


### PR DESCRIPTION
🎯 **What:** Removed unused `List` import from `typing` in `services/relationship_verification_service/handlers.py`.
💡 **Why:** Having unused imports slightly pollutes the namespace and can trigger linter warnings. Removing it improves the codebase health and readability.
✅ **Verification:** Verified by running `python3 -m py_compile` to ensure syntax is valid. Tests were executed using `pytest` (0 items collected, as expected for this stubbed service). Code was reviewed and confirmed safe.
✨ **Result:** A slightly cleaner and more maintainable `handlers.py` file with no functional changes.

---
*PR created automatically by Jules for task [6641057532916875929](https://jules.google.com/task/6641057532916875929) started by @chifamba*