### PR TITLE
🔒 Enforce JWT_SECRET configuration in genealogy_service

### DIFF
--- a/services/genealogy_service/config.py
+++ b/services/genealogy_service/config.py
@@ -3,3 +3,6 @@
 import os
 
 JWT_SECRET = os.environ.get("JWT_SECRET")
+
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is not set")


### PR DESCRIPTION
🎯 **What:** Modified `services/genealogy_service/config.py` to ensure the application fails fast if `JWT_SECRET` is not set in the environment variables, rather than silently falling back to a `None` value.

⚠️ **Risk:** If the `JWT_SECRET` is missing, `os.environ.get("JWT_SECRET")` defaults to `None`. This means the `jwt.decode` function in `handlers.py` would use `None` as the signature key. This is a severe security vulnerability because it could allow attackers to forge tokens with an empty signature or bypass authentication entirely, giving unauthorized access to sensitive family tree data.

🛡️ **Solution:** Added a check in `config.py` that raises a `RuntimeError` if the `JWT_SECRET` environment variable evaluates to a falsy value (e.g. `None` or an empty string). This securely enforces the presence of the secret before the application can start.

---
*PR created automatically by Jules for task [13906328575099374751](https://jules.google.com/task/13906328575099374751) started by @chifamba*