### PR TITLE
🧹 Remove unused Optional import in search_discovery_service

### DIFF
--- a/services/search_discovery_service/handlers.py
+++ b/services/search_discovery_service/handlers.py
@@ -1,7 +1,7 @@
 """Request handlers for search_discovery_service service."""
 
 from fastapi import APIRouter
-from typing import List, Dict, Optional
+from typing import Dict
 
 router = APIRouter()
 


### PR DESCRIPTION
🎯 **What:** Removed unused `Optional` and `List` from `typing` module imports in `services/search_discovery_service/handlers.py`.
💡 **Why:** To improve code maintainability, clean up the namespace, and slightly improve readability.
✅ **Verification:** Verified that neither `Optional` nor `List` were used anywhere else in the file. Ran `python3 -m py_compile` to ensure syntactic correctness, and executed pytest against the directory (no tests currently exist, but verified it runs). Code review marked the change as Correct.
✨ **Result:** A cleaner import statement (`from typing import Dict`) that accurately reflects the file's dependencies.

---
*PR created automatically by Jules for task [13350310954819838566](https://jules.google.com/task/13350310954819838566) started by @chifamba*