### PR TITLE
🔒 [Security] Fix overly permissive CORS policy in API services

### DIFF
--- a/services/auth_service/config.py
+++ b/services/auth_service/config.py
@@ -6,3 +6,8 @@ DATABASE_URL = os.environ.get("DATABASE_URL")
 JWT_SECRET = os.environ.get("JWT_SECRET")
 GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID")
 REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+
+# Comma-separated list of allowed origins for CORS.
+# E.g., "https://example.com,https://app.example.com"
+# Fails secure by defaulting to an empty string (no allowed origins).
+CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "")

--- a/services/auth_service/main.py
+++ b/services/auth_service/main.py
@@ -12,10 +12,19 @@ Base.metadata.create_all(bind=engine)
 app = FastAPI()
 logger = setup_logging("auth_service")
 
+from config import CORS_ALLOWED_ORIGINS
 from fastapi.middleware.cors import CORSMiddleware
+
+# Parse allowed origins from environment. Default is empty (fails secure).
+allowed_origins = [
+    origin.strip()
+    for origin in CORS_ALLOWED_ORIGINS.split(",")
+    if origin.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify the frontend domain
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/genealogy_service/config.py
+++ b/services/genealogy_service/config.py
@@ -3,3 +3,8 @@
 import os
 
 JWT_SECRET = os.environ.get("JWT_SECRET")
+
+# Comma-separated list of allowed origins for CORS.
+# E.g., "https://example.com,https://app.example.com"
+# Fails secure by defaulting to an empty string (no allowed origins).
+CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "")

--- a/services/genealogy_service/main.py
+++ b/services/genealogy_service/main.py
@@ -8,10 +8,19 @@ from handlers import router as genealogy_router
 app = FastAPI()
 logger = setup_logging("genealogy_service")
 
+from config import CORS_ALLOWED_ORIGINS
 from fastapi.middleware.cors import CORSMiddleware
+
+# Parse allowed origins from environment. Default is empty (fails secure).
+allowed_origins = [
+    origin.strip()
+    for origin in CORS_ALLOWED_ORIGINS.split(",")
+    if origin.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify the frontend domain
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/help_support_service/config.py
+++ b/services/help_support_service/config.py
@@ -36,3 +36,9 @@ SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "")
 # Chat Configuration
 CHAT_MAX_CONNECTIONS = int(os.getenv("CHAT_MAX_CONNECTIONS", "100"))
 CHAT_TIMEOUT_MINUTES = int(os.getenv("CHAT_TIMEOUT_MINUTES", "30"))
+
+# Security Configuration
+# Comma-separated list of allowed origins for CORS.
+# E.g., "https://example.com,https://app.example.com"
+# Fails secure by defaulting to an empty string (no allowed origins).
+CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "")

--- a/services/help_support_service/main.py
+++ b/services/help_support_service/main.py
@@ -3,6 +3,7 @@ Help Support Service
 Provides ticketing system, live chat, knowledge base, and community forums.
 """
 
+from config import CORS_ALLOWED_ORIGINS
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from handlers import router
@@ -13,10 +14,17 @@ app = FastAPI(
     version="1.0.0"
 )
 
+# Parse allowed origins from environment. Default is empty (fails secure).
+allowed_origins = [
+    origin.strip()
+    for origin in CORS_ALLOWED_ORIGINS.split(",")
+    if origin.strip()
+]
+
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure appropriately for production
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🎯 **What:** 
Fixed an overly permissive CORS policy (`allow_origins=["*"]`) across multiple FastAPI microservices (`genealogy_service`, `auth_service`, `help_support_service`).

⚠️ **Risk:** 
Allowing all origins (`*`) with `allow_credentials=True` exposes the APIs to Cross-Site Request Forgery (CSRF) and malicious cross-origin data reads. An attacker could trick an authenticated user into visiting a malicious website, which would then make unauthorized requests (including state-changing actions or sensitive data retrieval) to the APIs on the user's behalf.

🛡️ **Solution:** 
Replaced the hardcoded wildcard with an environment-variable driven configuration (`CORS_ALLOWED_ORIGINS`). It parses a comma-separated list of trusted origins and defaults to an empty list if not set. This guarantees a "fail-secure" posture, completely disabling cross-origin requests unless explicitly configured for specific frontend domains.

---
*PR created automatically by Jules for task [8819229826590161824](https://jules.google.com/task/8819229826590161824) started by @chifamba*