### PR TITLE
🔒 Fix overly permissive CORS policy in auth_service

### DIFF
--- a/services/auth_service/config.py
+++ b/services/auth_service/config.py
@@ -6,3 +6,8 @@ DATABASE_URL = os.environ.get("DATABASE_URL")
 JWT_SECRET = os.environ.get("JWT_SECRET")
 GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID")
 REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+CORS_ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    if origin.strip()
+]

--- a/services/auth_service/main.py
+++ b/services/auth_service/main.py
@@ -13,9 +13,11 @@ app = FastAPI()
 logger = setup_logging("auth_service")
 
 from fastapi.middleware.cors import CORSMiddleware
+from config import CORS_ALLOWED_ORIGINS
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify the frontend domain
+    allow_origins=CORS_ALLOWED_ORIGINS,  # Securely configured via environment variables
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `auth_service` was using a highly permissive CORS configuration (`allow_origins=["*"]`) combined with `allow_credentials=True`. This has been updated to use a whitelist of allowed origins loaded from environment variables (`CORS_ALLOWED_ORIGINS`).

⚠️ **Risk:** The potential impact if left unfixed
A wildcard `allow_origins` policy while `allow_credentials=True` is enabled allows arbitrary origins to make credentialed requests (sending cookies, authorization headers, or TLS client certificates). This enables Cross-Origin Resource Sharing attacks, effectively allowing malicious sites to read sensitive authenticated data from the API on behalf of the victim user. In this context, it could lead to stolen JWT tokens or user information.

🛡️ **Solution:** How the fix addresses the vulnerability
The `config.py` in the `auth_service` now parses the `CORS_ALLOWED_ORIGINS` environment variable, defaulting to `"http://localhost:3000"` (to not break local development). The `main.py` has been updated to import this specific list of allowed origins and supply it to the `CORSMiddleware`. This effectively blocks unknown and potentially malicious cross-origin requests.

---
*PR created automatically by Jules for task [1078753943216945577](https://jules.google.com/task/1078753943216945577) started by @chifamba*