### PR TITLE
🔒 Fix Overly Permissive CORS Policy in Help Support Service

### DIFF
--- a/services/help_support_service/config.py
+++ b/services/help_support_service/config.py
@@ -26,6 +26,7 @@ MONGODB_HELP_DB = os.getenv("MONGODB_HELP_DB", "dzinza_help")
 # Service Configuration
 SERVICE_NAME = "help_support_service"
 SERVICE_PORT = int(os.getenv("SERVICE_PORT", "8000"))
+ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",") if origin.strip()]
 
 # Email Configuration
 SMTP_HOST = os.getenv("SMTP_HOST", "localhost")

--- a/services/help_support_service/main.py
+++ b/services/help_support_service/main.py
@@ -6,6 +6,7 @@ Provides ticketing system, live chat, knowledge base, and community forums.
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from handlers import router
+from config import ALLOWED_ORIGINS
 
 app = FastAPI(
     title="Help Support Service",
@@ -16,7 +17,7 @@ app = FastAPI(
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure appropriately for production
+    allow_origins=ALLOWED_ORIGINS,  # Use allowed origins from config
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/help_support_service/test_cors.py
+++ b/services/help_support_service/test_cors.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi.testclient import TestClient
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'help_support_service'))
+import config
+
+# Set ALLOWED_ORIGINS for the test
+os.environ["ALLOWED_ORIGINS"] = "http://test-origin.com,http://another-test.com"
+
+# Reload config to apply environment variable changes
+import importlib
+importlib.reload(config)
+
+from main import app
+
+client = TestClient(app)
+
+def test_cors_allowed_origin():
+    response = client.options("/api/v1/health", headers={"Origin": "http://test-origin.com", "Access-Control-Request-Method": "GET"})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://test-origin.com"
+
+def test_cors_disallowed_origin():
+    response = client.options("/api/v1/health", headers={"Origin": "http://evil-origin.com", "Access-Control-Request-Method": "GET"})
+    assert response.status_code == 400 or response.headers.get("access-control-allow-origin") != "http://evil-origin.com"
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "service": "help_support_service"}


### PR DESCRIPTION
🔒 [Security Fix] Resolve overly permissive CORS configuration in the Help Support service.

🎯 **What:** The `help_support_service` was previously configured with `allow_origins=["*"]` while simultaneously setting `allow_credentials=True` in its FastAPI CORS middleware. This PR updates the service to read an `ALLOWED_ORIGINS` comma-separated string from environment variables, defaulting securely to `http://localhost:3000`.

⚠️ **Risk:** Configuring CORS with both wildcard origins and allowed credentials is a significant security vulnerability. It permits any malicious website to make cross-origin requests to the API while including the user's cookies or authorization headers, potentially leading to unauthorized data access or actions on behalf of the user.

🛡️ **Solution:** 
1. Added `ALLOWED_ORIGINS` to `services/help_support_service/config.py` which parses a comma-separated list from the environment.
2. Updated `services/help_support_service/main.py` to import and utilize this explicit list in the `CORSMiddleware` configuration.
3. Added `test_cors.py` to verify that requests from allowed origins are accepted and others are restricted appropriately.

---
*PR created automatically by Jules for task [8897117160721730453](https://jules.google.com/task/8897117160721730453) started by @chifamba*