### PR TITLE
🧹 [code health] Implement secure media access validation in media_storage_service

### DIFF
--- a/services/media_storage_service/config.py
+++ b/services/media_storage_service/config.py
@@ -1,1 +1,4 @@
 """Configuration for media_storage_service service."""
+import os
+
+JWT_SECRET = os.environ.get("JWT_SECRET")

--- a/services/media_storage_service/handlers.py
+++ b/services/media_storage_service/handlers.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from minio import Minio
 import os
+import jwt
 from .metadata import (
     add_tag, get_tags, add_to_album, get_album,
     search_by_tag, add_media_date, get_media_timeline
@@ -69,13 +70,31 @@ async def bulk_upload(files: list[UploadFile] = File(...), folder: str = None):
 @router.get("/media/{filename}")
 def get_media(filename: str, token: str = None, decrypt: bool = False, user: str = None):
     """
-    Secure media access placeholder. In production, validate token and permissions.
+    Secure media access. Validates token and permissions for secured resources.
     """
-    # TODO: Validate token and user permissions for secure access
-    # Simple ACL check
     acl = _media_acl.get(filename, set())
-    if acl and user and user not in acl:
-        raise HTTPException(status_code=403, detail="Access denied")
+    if acl:
+        if not token:
+            raise HTTPException(status_code=401, detail="Authentication token required for secured media")
+        import services.media_storage_service.config
+        secret = services.media_storage_service.config.JWT_SECRET
+        if not secret:
+            raise HTTPException(status_code=500, detail="JWT_SECRET not configured")
+        try:
+            payload = jwt.decode(token, secret, algorithms=["HS256"])
+            token_user = payload.get("sub")
+        except jwt.PyJWTError:
+            raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+        if not token_user:
+            raise HTTPException(status_code=401, detail="Invalid token payload")
+
+        if user and user != token_user:
+            raise HTTPException(status_code=403, detail="User parameter does not match token identity")
+
+        if token_user not in acl:
+            raise HTTPException(status_code=403, detail="Access denied")
+
     try:
         response = minio_client.get_object(MINIO_BUCKET, filename)
         data = response.read()

--- a/services/media_storage_service/test_handlers.py
+++ b/services/media_storage_service/test_handlers.py
@@ -1,0 +1,77 @@
+import sys
+from unittest.mock import MagicMock
+import jwt
+
+sys.modules['minio'] = MagicMock()
+sys.modules['redis'] = MagicMock()
+sys.modules['PIL'] = MagicMock()
+sys.modules['PIL.ExifTags'] = MagicMock()
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from services.media_storage_service.handlers import router, _media_acl, minio_client
+import services.media_storage_service.config
+
+# Mock JWT_SECRET for tests
+services.media_storage_service.config.JWT_SECRET = "testsecret"
+JWT_SECRET = services.media_storage_service.config.JWT_SECRET
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+def setup_function():
+    _media_acl.clear()
+
+def test_get_media_no_acl():
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"data"
+    minio_client.get_object.return_value = mock_response
+
+    response = client.get("/media/public.jpg")
+    assert response.status_code == 200
+
+def test_get_media_acl_no_token():
+    _media_acl["secured.jpg"] = {"user1"}
+    response = client.get("/media/secured.jpg")
+    assert response.status_code == 401
+    assert "token required" in response.json()["detail"].lower()
+
+def test_get_media_acl_invalid_token():
+    _media_acl["secured.jpg"] = {"user1"}
+    response = client.get("/media/secured.jpg?token=invalid_token")
+    assert response.status_code == 401
+    assert "invalid or expired token" in response.json()["detail"].lower()
+
+def test_get_media_acl_valid_token_not_in_acl():
+    _media_acl["secured.jpg"] = {"user1"}
+    token = jwt.encode({"sub": "user2"}, JWT_SECRET, algorithm="HS256")
+    response = client.get(f"/media/secured.jpg?token={token}")
+    assert response.status_code == 403
+    assert "access denied" in response.json()["detail"].lower()
+
+def test_get_media_acl_valid_token_in_acl():
+    _media_acl["secured.jpg"] = {"user1"}
+    token = jwt.encode({"sub": "user1"}, JWT_SECRET, algorithm="HS256")
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"data"
+    minio_client.get_object.return_value = mock_response
+
+    response = client.get(f"/media/secured.jpg?token={token}")
+    assert response.status_code == 200
+
+def test_get_media_acl_mismatched_user_param():
+    _media_acl["secured.jpg"] = {"user1"}
+    token = jwt.encode({"sub": "user1"}, JWT_SECRET, algorithm="HS256")
+    response = client.get(f"/media/secured.jpg?token={token}&user=user2")
+    assert response.status_code == 403
+    assert "does not match token" in response.json()["detail"].lower()
+
+def test_get_media_acl_no_sub_in_token():
+    _media_acl["secured.jpg"] = {"user1"}
+    token = jwt.encode({"not_sub": "user1"}, JWT_SECRET, algorithm="HS256")
+    response = client.get(f"/media/secured.jpg?token={token}")
+    assert response.status_code == 401
+    assert "invalid token payload" in response.json()["detail"].lower()


### PR DESCRIPTION
🎯 **What:** Implemented secure media access by adding proper JWT token validation to the `get_media` endpoint in `services/media_storage_service/handlers.py`, replacing a TODO placeholder.

💡 **Why:** To enforce strict Access Control Lists (ACL) on private media files. The code now ensures that if a file is secured, only users presenting a valid JWT token that decodes to an authorized user identity (`sub` claim) can retrieve it.

✅ **Verification:** Verified by writing and executing a comprehensive set of Pytest unit tests in `services/media_storage_service/test_handlers.py`. Covered scenarios include valid access, missing token, invalid token, valid token but unauthorized user, and mismatched user identity. All tests successfully passed. Also ensured that missing `JWT_SECRET` returns an internal server error to fail securely.

✨ **Result:** Enhanced the codebase's maintainability and security posture by fully implementing missing authorization logic for media files, removing a critical TODO item.

---
*PR created automatically by Jules for task [3140250064267479904](https://jules.google.com/task/3140250064267479904) started by @chifamba*