### PR TITLE
🔒 Remove hardcoded MinIO default credentials

### DIFF
--- a/services/media_storage_service/handlers.py
+++ b/services/media_storage_service/handlers.py
@@ -14,9 +14,12 @@ import subprocess
 router = APIRouter()
 
 MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "garage1:39000")
-MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
-MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minioadmin")
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "media")
+
+if not MINIO_ACCESS_KEY or not MINIO_SECRET_KEY:
+    raise RuntimeError("MINIO_ACCESS_KEY and MINIO_SECRET_KEY environment variables must be set.")
 
 minio_client = Minio(
     MINIO_ENDPOINT,


### PR DESCRIPTION
🎯 **What:** The `services/media_storage_service/handlers.py` file contained hardcoded default values ("minioadmin") for the MinIO storage credentials (`MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`). This commit removes those insecure defaults and replaces them with a runtime check that enforces explicit configuration.

⚠️ **Risk:** If the application were deployed without these environment variables set, an attacker who discovered the MinIO endpoint could use the default "minioadmin" credentials to gain full administrative access to the media storage bucket. This would allow unauthorized data access, modification, or deletion.

🛡️ **Solution:** The hardcoded defaults were removed from `os.getenv()`. Instead, the code now reads the environment variables and raises a `RuntimeError` if either is missing. This fail-fast mechanism guarantees that the service cannot start in an insecure state and forces administrators to explicitly provide secure credentials.

---
*PR created automatically by Jules for task [13603549321472710360](https://jules.google.com/task/13603549321472710360) started by @chifamba*