### PR TITLE
🔒 Fix hardcoded JWT secret vulnerability in Graph Query Service

### DIFF
--- a/services/graph_query_service/config.py
+++ b/services/graph_query_service/config.py
@@ -1,1 +1,14 @@
 """Configuration for graph_query_service service."""
+
+import os
+
+JWT_SECRET = os.environ.get("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is required")
+
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+
+NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD")
+if not NEO4J_PASSWORD:
+    raise RuntimeError("NEO4J_PASSWORD environment variable is required")

--- a/services/graph_query_service/main.py
+++ b/services/graph_query_service/main.py
@@ -20,10 +20,9 @@ security = HTTPBearer()
 
 def verify_jwt(credentials: HTTPAuthorizationCredentials = Depends(security)):
     import jwt
-    import os
-    secret = os.getenv("JWT_SECRET", "testsecret")
+    from .config import JWT_SECRET
     try:
-        payload = jwt.decode(credentials.credentials, secret, algorithms=["HS256"])
+        payload = jwt.decode(credentials.credentials, JWT_SECRET, algorithms=["HS256"])
         return payload
     except Exception:
         raise HTTPException(
@@ -59,9 +58,8 @@ async def auth_middleware(request: Request, call_next):
             if scheme.lower() != "bearer":
                 raise ValueError()
             import jwt
-            import os
-            secret = os.getenv("JWT_SECRET", "testsecret")
-            payload = jwt.decode(token, secret, algorithms=["HS256"])
+            from .config import JWT_SECRET
+            payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
             # Authorization: require role claim
             if "role" not in payload or payload["role"] not in ["user", "admin"]:
                 raise HTTPException(status_code=403, detail="Insufficient permissions")

--- a/services/graph_query_service/models.py
+++ b/services/graph_query_service/models.py
@@ -4,7 +4,5 @@ from neo4j import GraphDatabase
 import os
 
 def get_neo4j_driver():
-    uri = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
-    user = os.getenv("NEO4J_USER", "neo4j")
-    password = os.getenv("NEO4J_PASSWORD", "testpassword")
-    return GraphDatabase.driver(uri, auth=(user, password))
+    from .config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
+    return GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded fallback values for `JWT_SECRET` and `NEO4J_PASSWORD` in `services/graph_query_service`.
⚠️ **Risk:** Hardcoding secrets like `"testsecret"` is a significant security vulnerability. If the environment variables are unintentionally omitted during deployment, the service would silently fall back to known, insecure secrets, potentially allowing unauthorized access to the GraphQL API and database.
🛡️ **Solution:** Centralized configuration management in `services/graph_query_service/config.py`. The service now strictly enforces that both `JWT_SECRET` and `NEO4J_PASSWORD` environment variables are present at startup by raising a `RuntimeError` if they are missing, ensuring a fail-closed secure posture. Updated `main.py` and `models.py` to import these explicit configurations instead of falling back to default strings.

---
*PR created automatically by Jules for task [9477801915702986122](https://jules.google.com/task/9477801915702986122) started by @chifamba*