### PR TITLE
🔒 Fix insecure JWT Secret configuration

### DIFF
--- a/services/auth_service/config.py
+++ b/services/auth_service/config.py
@@ -4,5 +4,9 @@ import os
 
 DATABASE_URL = os.environ.get("DATABASE_URL")
 JWT_SECRET = os.environ.get("JWT_SECRET")
+
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is mandatory")
+
 GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID")
 REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")

--- a/services/genealogy_service/config.py
+++ b/services/genealogy_service/config.py
@@ -3,3 +3,6 @@
 import os
 
 JWT_SECRET = os.environ.get("JWT_SECRET")
+
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is mandatory")


### PR DESCRIPTION
🎯 **What:** 
The application configuration for `auth_service` and `genealogy_service` read `JWT_SECRET` from environment variables, but did not enforce its presence. This could allow the services to start up with a weak, insecure configuration (e.g., `None` or empty string) if the environment variable was missing.

⚠️ **Risk:** 
If the `JWT_SECRET` falls back to `None` or an empty string, the application signs JWTs with a highly predictable (or zero-length) secret. This makes it trivial for attackers to forge valid JWTs and impersonate any user or gain administrative access to the system, causing a critical compromise. 

🛡️ **Solution:** 
Updated `services/auth_service/config.py` and `services/genealogy_service/config.py` to add a strict check. If `JWT_SECRET` is not provided (or evaluates to empty), the services will immediately raise a `RuntimeError` on startup. This "fail-fast" approach guarantees the application will never run in an insecure state.

---
*PR created automatically by Jules for task [4852676202396028910](https://jules.google.com/task/4852676202396028910) started by @chifamba*