### PR TITLE
🔒 Fix hardcoded NEO4J_PASSWORD and JWT_SECRET vulnerabilities

### DIFF
--- a/services/genealogy_service/config.py
+++ b/services/genealogy_service/config.py
@@ -2,4 +2,14 @@
 
 import os
 
-JWT_SECRET = os.environ.get("JWT_SECRET")
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
+
+if not NEO4J_PASSWORD:
+    raise RuntimeError("NEO4J_PASSWORD environment variable must be set")
+
+JWT_SECRET = os.getenv("JWT_SECRET")
+
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable must be set")

--- a/services/genealogy_service/models.py
+++ b/services/genealogy_service/models.py
@@ -1,10 +1,7 @@
 """Data models for genealogy_service service."""
 
 from neo4j import GraphDatabase
-import os
+from config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
 
 def get_neo4j_driver():
-    uri = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
-    user = os.getenv("NEO4J_USER", "neo4j")
-    password = os.getenv("NEO4J_PASSWORD", "testpassword")
-    return GraphDatabase.driver(uri, auth=(user, password))
+    return GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))

--- a/services/graph_query_service/config.py
+++ b/services/graph_query_service/config.py
@@ -1,1 +1,15 @@
 """Configuration for graph_query_service service."""
+
+import os
+
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
+
+if not NEO4J_PASSWORD:
+    raise RuntimeError("NEO4J_PASSWORD environment variable must be set")
+
+JWT_SECRET = os.getenv("JWT_SECRET")
+
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable must be set")

--- a/services/graph_query_service/main.py
+++ b/services/graph_query_service/main.py
@@ -20,10 +20,9 @@ security = HTTPBearer()
 
 def verify_jwt(credentials: HTTPAuthorizationCredentials = Depends(security)):
     import jwt
-    import os
-    secret = os.getenv("JWT_SECRET", "testsecret")
+    from config import JWT_SECRET
     try:
-        payload = jwt.decode(credentials.credentials, secret, algorithms=["HS256"])
+        payload = jwt.decode(credentials.credentials, JWT_SECRET, algorithms=["HS256"])
         return payload
     except Exception:
         raise HTTPException(
@@ -59,9 +58,8 @@ async def auth_middleware(request: Request, call_next):
             if scheme.lower() != "bearer":
                 raise ValueError()
             import jwt
-            import os
-            secret = os.getenv("JWT_SECRET", "testsecret")
-            payload = jwt.decode(token, secret, algorithms=["HS256"])
+            from config import JWT_SECRET
+            payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
             # Authorization: require role claim
             if "role" not in payload or payload["role"] not in ["user", "admin"]:
                 raise HTTPException(status_code=403, detail="Insufficient permissions")

--- a/services/graph_query_service/models.py
+++ b/services/graph_query_service/models.py
@@ -1,10 +1,7 @@
 """Data models for graph_query_service service."""
 
 from neo4j import GraphDatabase
-import os
+from config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
 
 def get_neo4j_driver():
-    uri = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
-    user = os.getenv("NEO4J_USER", "neo4j")
-    password = os.getenv("NEO4J_PASSWORD", "testpassword")
-    return GraphDatabase.driver(uri, auth=(user, password))
+    return GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Hardcoded database credentials (`"testpassword"`) for Neo4j and authentication secrets (`"testsecret"`) for JWT validation were used as fallbacks directly in the code.

⚠️ **Risk:** The potential impact if left unfixed
If an environment variable was accidentally omitted or failed to load in a production deployment, the applications would fall back to easily guessable, hardcoded credentials. This could allow an attacker to bypass authentication, query sensitive GraphQL data, or manipulate the Neo4j genealogy database.

🛡️ **Solution:** How the fix addresses the vulnerability
The hardcoded fallbacks were completely removed. Now, both `graph_query_service` and `genealogy_service` read `NEO4J_PASSWORD` and `JWT_SECRET` through a centralized `config.py` module. If either environment variable is missing, the service immediately raises a `RuntimeError` during startup, adopting a fail-fast approach that prevents booting into a vulnerable state. All services were unified to use local absolute imports (`from config import`) for consistency.

---
*PR created automatically by Jules for task [13656222028993635277](https://jules.google.com/task/13656222028993635277) started by @chifamba*