### PR TITLE
⚡ [performance improvement] Optimize media bulk upload with asyncio.gather and threadpool

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,35 @@
+import asyncio
+import time
+from unittest.mock import MagicMock
+from fastapi import UploadFile
+
+import sys
+sys.path.append("/app")
+
+import services.media_storage_service.handlers as handlers
+
+async def main():
+    handlers.minio_client = MagicMock()
+
+    def slow_put(*args, **kwargs):
+        time.sleep(0.05) # Simulate slow sync upload
+
+    handlers.minio_client.put_object.side_effect = slow_put
+
+    class MockFile:
+        def __init__(self, name):
+            self.filename = name
+            self.content_type = "text/plain"
+
+        async def read(self):
+            await asyncio.sleep(0.05) # Simulate async read
+            return b"content"
+
+    files = [MockFile(f"file_{i}.txt") for i in range(10)]
+
+    start = time.time()
+    await handlers.bulk_upload(files, folder="test")
+    end = time.time()
+    print(f"Time taken: {end - start:.4f} seconds")
+
+asyncio.run(main())

--- a/services/media_storage_service/handlers.py
+++ b/services/media_storage_service/handlers.py
@@ -1,6 +1,8 @@
 """Request handlers for media_storage_service."""
 
+import asyncio
 from fastapi import APIRouter, UploadFile, File, HTTPException
+from starlette.concurrency import run_in_threadpool
 from minio import Minio
 import os
 from .metadata import (
@@ -47,23 +49,27 @@ async def upload_media(file: UploadFile = File(...), folder: str = None):
 
 @router.post("/upload/bulk/")
 async def bulk_upload(files: list[UploadFile] = File(...), folder: str = None):
-    results = []
-    for file in files:
+    async def process_file(file: UploadFile):
         try:
             content = await file.read()
             filename = file.filename
             if folder:
                 filename = f"{folder}/{filename}"
-            minio_client.put_object(
+
+            await run_in_threadpool(
+                minio_client.put_object,
                 MINIO_BUCKET,
                 filename,
                 content,
                 length=len(content),
                 content_type=file.content_type,
             )
-            results.append({"filename": filename, "status": "uploaded"})
+            return {"filename": filename, "status": "uploaded"}
         except Exception as e:
-            results.append({"filename": file.filename, "status": "error", "error": str(e)})
+            return {"filename": file.filename, "status": "error", "error": str(e)}
+
+    tasks = [process_file(file) for file in files]
+    results = await asyncio.gather(*tasks)
     return results
 
 @router.get("/media/{filename}")


### PR DESCRIPTION
💡 **What:**
Optimized the `/upload/bulk/` endpoint in `services/media_storage_service/handlers.py` by replacing a sequential `for` loop with concurrent task execution using `asyncio.gather()`. Additionally, wrapped the synchronous `minio_client.put_object` I/O operation inside `starlette.concurrency.run_in_threadpool`.

🎯 **Why:**
The previous implementation uploaded files one by one, awaiting the result of `file.read()` and blocking the main thread while performing the synchronous `minio_client.put_object` network request. This resulted in poor performance that scaled linearly (O(N)) with the number of files and blocked the FastAPI event loop, severely degrading the performance of the entire service during a bulk upload. By uploading concurrently and offloading the blocking I/O to a thread pool, the endpoint now processes files in parallel without blocking the main event loop.

📊 **Measured Improvement:**
A benchmark was created to upload 10 mock files (with a simulated 0.05s network delay and 0.05s read time per file).
- **Baseline:** ~1.0086 seconds
- **Optimized:** ~0.1224 seconds
- **Improvement:** Reduced upload time by approximately 88% (an 8.2x speedup) for 10 files.

---
*PR created automatically by Jules for task [4256368781142495822](https://jules.google.com/task/4256368781142495822) started by @chifamba*