### PR TITLE
🔒 fix data leakage via unfiltered exceptions in graph_query_service

### DIFF
--- a/services/graph_query_service/main.py
+++ b/services/graph_query_service/main.py
@@ -109,7 +109,7 @@ async def graphql_error_handler(request, exc):
     logger.error(f"GraphQL error: {exc}")
     return JSONResponse(
         status_code=500,
-        content={"errors": [{"message": str(exc)}]}
+        content={"errors": [{"message": "Internal server error"}]}
     )
 
 app.include_router(graphql_app, prefix="/graphql")


### PR DESCRIPTION
🎯 **What:** Modified the global exception handler (`graphql_error_handler`) in `services/graph_query_service/main.py` to return a generic `"Internal server error"` message instead of exposing the raw exception details `str(exc)` in the `JSONResponse`.

⚠️ **Risk:** The previous implementation exposed raw internal server errors directly to clients via HTTP 500 responses. This created a potential data leakage vulnerability, where sensitive internal system details, database query structures, or logic could be exposed to end users and potentially malicious actors.

🛡️ **Solution:** The handler now safely logs the full exception detail internally (`logger.error(f"GraphQL error: {exc}")`) for debugging purposes but returns a standardized, sanitized `"Internal server error"` message in the JSON payload to the user, effectively closing the data leak vector without compromising operational observability.

---
*PR created automatically by Jules for task [8927780169062633672](https://jules.google.com/task/8927780169062633672) started by @chifamba*