### PR TITLE
🔒 [Security] Remove hardcoded passwords from config

### DIFF
--- a/services/help_support_service/config.py
+++ b/services/help_support_service/config.py
@@ -9,18 +9,18 @@ DB_HOST = os.getenv("DB_HOST", "postgres")
 DB_PORT = int(os.getenv("DB_PORT", "5432"))
 DB_NAME = os.getenv("DB_NAME", "dzinza_db")
 DB_USER = os.getenv("DB_USER", "dzinza_user")
-DB_PASSWORD = os.getenv("DB_PASSWORD", "secure_password_123")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
 
 # Redis Configuration
 REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
-REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", "redis_secure_password_789")
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
 
 # MongoDB Configuration
 MONGODB_HOST = os.getenv("MONGODB_HOST", "mongodb")
 MONGODB_PORT = int(os.getenv("MONGODB_PORT", "27017"))
 MONGODB_USER = os.getenv("MONGODB_USER", "dzinza_user")
-MONGODB_PASSWORD = os.getenv("MONGODB_PASSWORD", "mongo_secure_password_456")
+MONGODB_PASSWORD = os.getenv("MONGODB_PASSWORD")
 MONGODB_HELP_DB = os.getenv("MONGODB_HELP_DB", "dzinza_help")
 
 # Service Configuration


### PR DESCRIPTION
🎯 **What:** Removed hardcoded fallback passwords for database, redis, and mongodb configurations in `help_support_service`.

⚠️ **Risk:** Hardcoded default passwords present a significant security risk, as anyone with access to the codebase (or relying on default configurations) would know the credentials to these datastores, potentially leading to unauthorized data access and breaches.

🛡️ **Solution:** Removed the default string fallbacks for `DB_PASSWORD`, `REDIS_PASSWORD`, and `MONGODB_PASSWORD` so that they only load from environment variables. Now they default to `None` if the environment variable is not set, adhering to security best practices.

---
*PR created automatically by Jules for task [16116497819776948110](https://jules.google.com/task/16116497819776948110) started by @chifamba*