### PR TITLE
🔒 Fix hardcoded fallback passwords across configurations

### DIFF
--- a/services/help_support_service/config.py
+++ b/services/help_support_service/config.py
@@ -9,18 +9,24 @@ DB_HOST = os.getenv("DB_HOST", "postgres")
 DB_PORT = int(os.getenv("DB_PORT", "5432"))
 DB_NAME = os.getenv("DB_NAME", "dzinza_db")
 DB_USER = os.getenv("DB_USER", "dzinza_user")
-DB_PASSWORD = os.getenv("DB_PASSWORD", "secure_password_123")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+if not DB_PASSWORD:
+    raise RuntimeError("DB_PASSWORD environment variable must be set")
 
 # Redis Configuration
 REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
-REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", "redis_secure_password_789")
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
+if not REDIS_PASSWORD:
+    raise RuntimeError("REDIS_PASSWORD environment variable must be set")
 
 # MongoDB Configuration
 MONGODB_HOST = os.getenv("MONGODB_HOST", "mongodb")
 MONGODB_PORT = int(os.getenv("MONGODB_PORT", "27017"))
 MONGODB_USER = os.getenv("MONGODB_USER", "dzinza_user")
-MONGODB_PASSWORD = os.getenv("MONGODB_PASSWORD", "mongo_secure_password_456")
+MONGODB_PASSWORD = os.getenv("MONGODB_PASSWORD")
+if not MONGODB_PASSWORD:
+    raise RuntimeError("MONGODB_PASSWORD environment variable must be set")
 MONGODB_HELP_DB = os.getenv("MONGODB_HELP_DB", "dzinza_help")
 
 # Service Configuration

--- a/services/media_storage_service/metadata.py
+++ b/services/media_storage_service/metadata.py
@@ -5,7 +5,9 @@ import redis
 
 REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
-REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", "redis_secure_password_789")
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
+if not REDIS_PASSWORD:
+    raise RuntimeError("REDIS_PASSWORD environment variable must be set")
 
 r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, password=REDIS_PASSWORD, decode_responses=True)
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Hardcoded fallback passwords for database connections (`DB_PASSWORD`, `REDIS_PASSWORD`, `MONGODB_PASSWORD`) were present in `services/help_support_service/config.py`. Another occurrence of a hardcoded fallback for `REDIS_PASSWORD` was found in `services/media_storage_service/metadata.py`. These fallbacks were removed, and the application now enforces that the environment variables must be provided at runtime.

⚠️ **Risk:** The potential impact if left unfixed
Hardcoded passwords, even as default fallbacks, pose a severe security risk. If an environment variable fails to load, the service defaults to an exposed, commonly known password. This could allow an attacker who gains access to the database ports to easily authenticate and read, modify, or delete sensitive data across Postgres, MongoDB, and Redis. It also violates basic security principles, potentially failing audits and making credential rotation more complex.

🛡️ **Solution:** How the fix addresses the vulnerability
The configuration and metadata files were updated to read from `os.getenv` without a second parameter (the default value). We then introduced checks `if not <VARIABLE>:` that raise a `RuntimeError` during module initialization. This creates a fail-safe (fail-closed) startup state where the service simply will not run if the required secrets are not provided, fully eliminating the possibility of falling back to unsafe credentials.

---
*PR created automatically by Jules for task [9300949633104039962](https://jules.google.com/task/9300949633104039962) started by @chifamba*