### PR TITLE
🔒 Fix hardcoded MinIO credentials in media_storage_service

### DIFF
--- a/services/media_storage_service/config.py
+++ b/services/media_storage_service/config.py
@@ -1,1 +1,14 @@
 """Configuration for media_storage_service service."""
+
+import os
+
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "garage1:39000")
+MINIO_BUCKET = os.getenv("MINIO_BUCKET", "media")
+
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY")
+if not MINIO_ACCESS_KEY:
+    raise RuntimeError("MINIO_ACCESS_KEY environment variable is missing")
+
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY")
+if not MINIO_SECRET_KEY:
+    raise RuntimeError("MINIO_SECRET_KEY environment variable is missing")

--- a/services/media_storage_service/handlers.py
+++ b/services/media_storage_service/handlers.py
@@ -11,12 +11,9 @@ from .exif_utils import extract_exif
 from .image_utils import compress_image, generate_thumbnail
 import subprocess
 
-router = APIRouter()
+from .config import MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY, MINIO_BUCKET
 
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "garage1:39000")
-MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
-MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minioadmin")
-MINIO_BUCKET = os.getenv("MINIO_BUCKET", "media")
+router = APIRouter()
 
 minio_client = Minio(
     MINIO_ENDPOINT,


### PR DESCRIPTION
🎯 **What:** The `media_storage_service` was using a default, hardcoded fallback `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` ("minioadmin") in its `handlers.py` file if environment variables were not explicitly set.

⚠️ **Risk:** If the service is deployed without the correct environment variables, it will default to using well-known, insecure default credentials ("minioadmin" / "minioadmin"). This poses a critical security risk as unauthorized parties could guess these credentials to read, modify, or delete sensitive media files stored in MinIO.

🛡️ **Solution:** The environment variable reading logic has been moved to a centralized `config.py` file. The default fallback values have been removed. The application now actively validates that both `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` are present in the environment; if either is missing, it raises a `RuntimeError` on startup to prevent the service from running in an insecure state. `handlers.py` has been updated to import these configuration variables securely.

---
*PR created automatically by Jules for task [1889058424419137274](https://jules.google.com/task/1889058424419137274) started by @chifamba*