### PR TITLE
🔒 [security fix] Remove hardcoded JWT secret fallback in graph_query_service

### DIFF
--- a/services/graph_query_service/main.py
+++ b/services/graph_query_service/main.py
@@ -21,7 +21,12 @@ security = HTTPBearer()
 def verify_jwt(credentials: HTTPAuthorizationCredentials = Depends(security)):
     import jwt
     import os
-    secret = os.getenv("JWT_SECRET", "testsecret")
+    secret = os.getenv("JWT_SECRET")
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="JWT_SECRET is not configured"
+        )
     try:
         payload = jwt.decode(credentials.credentials, secret, algorithms=["HS256"])
         return payload
@@ -33,7 +38,7 @@ def verify_jwt(credentials: HTTPAuthorizationCredentials = Depends(security)):
 
 # GraphQL setup
 schema = strawberry.Schema(query=Query)
-graphql_app = GraphQLRouter(schema, graphiql=True)
+graphql_app = GraphQLRouter(schema, graphql_ide="graphiql")
 
 import time
 
@@ -60,7 +65,10 @@ async def auth_middleware(request: Request, call_next):
                 raise ValueError()
             import jwt
             import os
-            secret = os.getenv("JWT_SECRET", "testsecret")
+            from fastapi.responses import JSONResponse
+            secret = os.getenv("JWT_SECRET")
+            if not secret:
+                return JSONResponse(status_code=500, content={"detail": "JWT_SECRET is not configured"})
             payload = jwt.decode(token, secret, algorithms=["HS256"])
             # Authorization: require role claim
             if "role" not in payload or payload["role"] not in ["user", "admin"]:


### PR DESCRIPTION
🎯 **What:** The `JWT_SECRET` environment variable was falling back to a hardcoded `"testsecret"` in `services/graph_query_service/main.py` if not configured in the environment. This happened in two places: `verify_jwt` dependency and `auth_middleware`. I replaced this fallback with a secure check that raises a `500 Internal Server Error` instead. Also updated `graphiql=True` to `graphql_ide="graphiql"` in `GraphQLRouter` initialization due to strawberry-graphql version compatibility updates discovered during testing.

⚠️ **Risk:** Critical severity. Leaving a fallback JWT secret essentially means the secret is publicly known and shared. Any user or attacker could easily forge authentication credentials, bypassing authorization logic, impersonating any user, and taking arbitrary actions across the system. 

🛡️ **Solution:** Removed the hardcoded `"testsecret"` fallback in `verify_jwt` and `auth_middleware` when reading `JWT_SECRET`. Instead, we now securely check if `JWT_SECRET` is unset, and if so, return a `500 Internal Server Error` (either an `HTTPException` or `JSONResponse`), immediately failing closed to prevent forged tokens from being validated securely.

---
*PR created automatically by Jules for task [12896243115757540103](https://jules.google.com/task/12896243115757540103) started by @chifamba*