### PR TITLE
🔒 Fix Media Access Token Bypass Vulnerability in get_media

### DIFF
--- a/services/media_storage_service/config.py
+++ b/services/media_storage_service/config.py
@@ -1,1 +1,5 @@
 """Configuration for media_storage_service service."""
+
+import os
+
+JWT_SECRET = os.environ.get("JWT_SECRET")

--- a/services/media_storage_service/handlers.py
+++ b/services/media_storage_service/handlers.py
@@ -3,6 +3,8 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from minio import Minio
 import os
+import jwt
+from .config import JWT_SECRET
 from .metadata import (
     add_tag, get_tags, add_to_album, get_album,
     search_by_tag, add_media_date, get_media_timeline
@@ -71,11 +73,25 @@ def get_media(filename: str, token: str = None, decrypt: bool = False, user: str
     """
     Secure media access placeholder. In production, validate token and permissions.
     """
-    # TODO: Validate token and user permissions for secure access
-    # Simple ACL check
     acl = _media_acl.get(filename, set())
-    if acl and user and user not in acl:
-        raise HTTPException(status_code=403, detail="Access denied")
+
+    # If the file is protected by ACL, require a valid token to identify the user
+    if acl:
+        if not token:
+            raise HTTPException(status_code=401, detail="Authentication token required")
+        if not JWT_SECRET:
+            raise HTTPException(status_code=500, detail="JWT_SECRET is not configured")
+
+        try:
+            payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+            # Override any user parameter with the authenticated identity from the token
+            user = payload.get("sub")
+        except jwt.PyJWTError:
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+        if not user or user not in acl:
+            raise HTTPException(status_code=403, detail="Access denied")
+
     try:
         response = minio_client.get_object(MINIO_BUCKET, filename)
         data = response.read()

--- a/services/media_storage_service/requirements.txt
+++ b/services/media_storage_service/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+pyjwt


### PR DESCRIPTION
🎯 **What:** The `get_media` endpoint in `media_storage_service` possessed an unvalidated `token` parameter and trusted an optional `user` query parameter for access control. This allowed files with an ACL to be accessed by simply supplying a forged `user` query parameter and omitting the token, completely bypassing authentication.

⚠️ **Risk:** High. Any user could retrieve ACL-protected files, such as private photos or sensitive documents, simply by providing a valid username in the query string (e.g., `?user=admin`) or by omitting both the token and the user parameter entirely. This could result in a massive data breach of private user content.

🛡️ **Solution:**
- Integrated `JWT_SECRET` via `os.environ` into `services/media_storage_service/config.py`.
- Updated `services/media_storage_service/requirements.txt` to include `pyjwt`.
- Modified `get_media` to enforce token validation using `pyjwt`.
- The user's identity is now exclusively derived from the token's `sub` claim, overriding any user-supplied `user` query parameter.
- Files protected by an ACL now explicitly require a valid token. If no token is provided, the API securely returns a `401 Unauthorized`.
- Maintained the existing behavior for public files (those without an ACL) to be accessible without a token.

---
*PR created automatically by Jules for task [9748983262833730364](https://jules.google.com/task/9748983262833730364) started by @chifamba*