### PR TITLE
🧹 [remove unused HTTPException import in audit_history_service/handlers.py]

### DIFF
--- a/services/audit_history_service/handlers.py
+++ b/services/audit_history_service/handlers.py
@@ -1,6 +1,6 @@
 """Handlers for Audit History Service."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from sqlalchemy.orm import Session
 from .models import AuditLog
 from pydantic import BaseModel


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an unused `HTTPException` import in `services/audit_history_service/handlers.py`.
💡 **Why:** This improves maintainability by keeping the import list clean and reducing noise in the codebase.
✅ **Verification:** Verified the change by running `python3 -m py_compile services/audit_history_service/handlers.py` (success) and running `pytest services/audit_history_service/` (collected 0 items, as expected).
✨ **Result:** A cleaner and more maintainable `handlers.py` file for the `audit_history_service`.

---
*PR created automatically by Jules for task [16923711251398121671](https://jules.google.com/task/16923711251398121671) started by @chifamba*