### PR TITLE
🔒 [security] Fix overly permissive CORS configuration

### DIFF
--- a/services/auth_service/main.py
+++ b/services/auth_service/main.py
@@ -1,5 +1,6 @@
 """Main entry point for auth_service service."""
 
+import os
 from fastapi import FastAPI
 from shared.app_logging import setup_logging
 from shared.healthcheck import get_healthcheck_router
@@ -15,7 +16,7 @@ logger = setup_logging("auth_service")
 from fastapi.middleware.cors import CORSMiddleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify the frontend domain
+    allow_origins=os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/genealogy_service/main.py
+++ b/services/genealogy_service/main.py
@@ -1,5 +1,6 @@
 """Main entry point for genealogy_service service."""
 
+import os
 from fastapi import FastAPI
 from shared.app_logging import setup_logging
 from shared.healthcheck import get_healthcheck_router
@@ -11,7 +12,7 @@ logger = setup_logging("genealogy_service")
 from fastapi.middleware.cors import CORSMiddleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify the frontend domain
+    allow_origins=os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/services/help_support_service/main.py
+++ b/services/help_support_service/main.py
@@ -3,6 +3,7 @@ Help Support Service
 Provides ticketing system, live chat, knowledge base, and community forums.
 """
 
+import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from handlers import router
@@ -16,7 +17,7 @@ app = FastAPI(
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure appropriately for production
+    allow_origins=os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🎯 **What:** 
Replaced the hardcoded `allow_origins=["*"]` wildcard in the CORS configuration for `genealogy_service`, `help_support_service`, and `auth_service` with dynamically loaded origins from the `ALLOWED_ORIGINS` environment variable, falling back to a secure default (`http://localhost:3000`).

⚠️ **Risk:** 
Setting `allow_origins=["*"]` combined with `allow_credentials=True` is fundamentally insecure. It instructs the browser to allow any external site to read the response of a credentialed request, thereby defeating the Same-Origin Policy and exposing authenticated user data to malicious cross-origin requests.

🛡️ **Solution:** 
Loaded trusted origins explicitly via environment variables (`ALLOWED_ORIGINS`). This enforces strict domain matching, allowing cross-origin requests only from known, authorized clients and restoring browser-enforced data protection.

---
*PR created automatically by Jules for task [9594150650231699542](https://jules.google.com/task/9594150650231699542) started by @chifamba*