### PR TITLE
🔒 Fix weak PRNG in MFA token generation

### DIFF
--- a/services/auth_service/handlers.py
+++ b/services/auth_service/handlers.py
@@ -118,8 +118,8 @@ def get_user_by_email(email: str, db: Session):
 @router.post("/enable_email_mfa")
 def enable_email_mfa(payload: schemas.EnableEmailMFARequest, db: Session = Depends(get_db)):
     user = get_user_by_email(payload.email, db)
-    import random
-    code = f"{random.randint(100000, 999999)}"
+    import secrets
+    code = f"{secrets.SystemRandom().randint(100000, 999999)}"
     
     # Store code in Redis with 10 minute expiration
     redis_client.setex(f"email_mfa:{payload.email}", 600, code)


### PR DESCRIPTION
🎯 What: Replaced `random.randint` with `secrets.SystemRandom().randint` for generating MFA tokens in `services/auth_service/handlers.py`.

⚠️ Risk: Using the standard `random` module for security-sensitive tokens makes the tokens predictable, potentially allowing an attacker to guess the MFA token and bypass authentication.

🛡️ Solution: The standard `secrets` module uses a cryptographically secure pseudo-random number generator (CSPRNG), making the tokens unpredictable and secure.

---
*PR created automatically by Jules for task [4655259533538787093](https://jules.google.com/task/4655259533538787093) started by @chifamba*