### PR TITLE
🧪 Add tests for deduplicate_address

### DIFF
--- a/services/deduplication_service/test_handlers.py
+++ b/services/deduplication_service/test_handlers.py
@@ -1,5 +1,6 @@
 import sys
 from unittest.mock import MagicMock
+import pytest
 
 # --- Mocking Infrastructure ---
 
@@ -30,10 +31,14 @@ sys.modules["fastapi"] = mock_fastapi
 # This assumes the 'services' directory is in PYTHONPATH.
 try:
     from deduplication_service.handlers import user_merge_approval
+    from deduplication_service import handlers
+    from deduplication_service.handlers import deduplicate_address
 except ImportError:
     # Fallback for different environments if necessary,
     # though the PYTHONPATH export in the test command is the primary method.
     from services.deduplication_service.handlers import user_merge_approval
+    from services.deduplication_service import handlers
+    from services.deduplication_service.handlers import deduplicate_address
 
 # --- Tests ---
 
@@ -81,3 +86,52 @@ def test_user_merge_approval_empty_strings():
         "merge_id": merge_id,
         "approved": approved
     }
+
+
+@pytest.fixture(autouse=True)
+def clear_profiles():
+    # Clear the global profiles list before each test
+    handlers.profiles.clear()
+    yield
+    handlers.profiles.clear()
+
+def test_deduplicate_address_no_duplicates():
+    """
+    Test deduplicate_address with no duplicates.
+    Verifies that the function returns an empty duplicates list when all addresses are unique.
+    """
+    handlers.profiles.extend([
+        {"id": "1", "address": "123 Main St"},
+        {"id": "2", "address": "456 Oak Ave"}
+    ])
+    result = deduplicate_address()
+    assert result == {"duplicates": []}
+
+def test_deduplicate_address_with_duplicates():
+    """
+    Test deduplicate_address with duplicates.
+    Verifies that the function accurately identifies duplicates, ignoring case sensitivity.
+    """
+    handlers.profiles.extend([
+        {"id": "1", "address": "123 Main St"},
+        {"id": "2", "address": "123 MAIN ST"},
+        {"id": "3", "address": "456 Oak Ave"}
+    ])
+    result = deduplicate_address()
+    assert len(result["duplicates"]) == 1
+    assert result["duplicates"][0] == {"id": "2", "address": "123 MAIN ST"}
+
+def test_deduplicate_address_missing_address():
+    """
+    Test deduplicate_address with missing or empty addresses.
+    Verifies that the function properly handles missing or empty address fields without crashing or false positives.
+    """
+    handlers.profiles.extend([
+        {"id": "1"}, # Missing address
+        {"id": "2", "address": ""}, # Empty address
+        {"id": "3", "address": "123 Main St"},
+        {"id": "4", "address": "123 Main St"}
+    ])
+    result = deduplicate_address()
+    assert len(result["duplicates"]) == 1
+    assert result["duplicates"][0] == {"id": "4", "address": "123 Main St"}


### PR DESCRIPTION
🎯 **What:** Addressed missing tests for deduplicate_address in services/deduplication_service/handlers.py.
📊 **Coverage:** Added test cases covering: no duplicate addresses, address duplicates (ignoring case), and missing/empty addresses.
✨ **Result:** Enhanced test coverage and prevented regressions for address deduplication logic.

---
*PR created automatically by Jules for task [7283482176224070264](https://jules.google.com/task/7283482176224070264) started by @chifamba*