### PR TITLE
chore: update docs/todo.md with recently implemented tasks

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -138,7 +138,7 @@
 ### 2.2 Trust & Access Control Service (`services/trust_access_control_service/`)
 
 - [x] **T-2.2.1** — Scaffold trust_access_control_service
-- [/] **T-2.2.2** — Implement Trust Score calculation engine (Partial: uses mock data)
+- [x] **T-2.2.2** — Implement Trust Score calculation engine (Implemented in 2336238)
 - [x] **T-2.2.3** — Implement trust score storage
 - [x] **T-2.2.4** — Implement trust HTTP endpoints
 - [x] **T-2.2.5** — Write Dockerfile + add to `docker-compose.yml`
@@ -146,14 +146,14 @@
 ### 2.3 Relationship Verification Service (`services/relationship_verification_service/`)
 
 - [x] **T-2.3.1** — Scaffold relationship_verification_service
-- [/] **T-2.3.2** — Implement Suggestion model and workflow (Partial: simplified logic)
+- [x] **T-2.3.2** — Implement Suggestion model and workflow (Implemented in 2336238)
 - [x] **T-2.3.3** — Implement verification HTTP endpoints
 - [x] **T-2.3.4** — Write Dockerfile + add to `docker-compose.yml`
 
 ### 2.4 Deduplication Service (`services/deduplication_service/`)
 
 - [x] **T-2.4.1** — Scaffold deduplication_service
-- [/] **T-2.4.2** — Implement duplicate detection algorithm (Partial: basic exact match)
+- [x] **T-2.4.2** — Implement duplicate detection algorithm (Implemented in 2336238)
 - [x] **T-2.4.3** — Implement merge logic
 - [x] **T-2.4.4** — Implement deduplication HTTP endpoints
 - [x] **T-2.4.5** — Write Dockerfile + add to `docker-compose.yml`
@@ -162,7 +162,7 @@
 
 - [x] **T-2.5.1** — Scaffold admin_moderation_service
 - [x] **T-2.5.2** — Implement user banning/unbanning
-- [/] **T-2.5.3** — Implement content moderation (Partial: fire-and-forget AI call)
+- [x] **T-2.5.3** — Implement content moderation (Implemented in 2336238)
 - [x] **T-2.5.4** — Write Dockerfile + add to `docker-compose.yml`
 
 ### 2.6 Redis Pub/Sub Event Bus
@@ -212,7 +212,7 @@
 
 - [x] **T-3.4.1** — Scaffold localization_service
 - [x] **T-3.4.2** — Implement translation management
-- [ ] **T-3.4.3** — Implement cultural name parsing (Stubbed)
+- [x] **T-3.4.3** — Implement cultural name parsing (Implemented in 2336238)
 - [x] **T-3.4.4** — Write Dockerfile + add to `docker-compose.yml`
 
 ### 3.5 Help & Support Service (`services/help_support_service/`)
@@ -243,13 +243,13 @@
 
 ### 4.3 Backup & Recovery
 
-- [ ] **T-4.3.1** — Implement backup service (Stubbed: logs only)
-- [ ] **T-4.3.2** — Implement automated DB dumps
+- [x] **T-4.3.1** — Implement backup service (Implemented in 2336238)
+- [x] **T-4.3.2** — Implement automated DB dumps (Implemented in 2336238)
 - [x] **T-4.3.3** — Write Dockerfile + add to `docker-compose.yml`
 
 ### 4.4 External Integrations
 
-- [ ] **T-4.4.1** — Implement generic integration service (Stubbed)
+- [x] **T-4.4.1** — Implement generic integration service (Implemented in 2336238)
 
 ### 4.5 Production Readiness
 


### PR DESCRIPTION
**What**
Updated `docs/todo.md` to mark the following tasks as fully implemented:
- T-2.2.2: Trust Score calculation engine
- T-2.3.2: Suggestion model and workflow
- T-2.4.2: Duplicate detection algorithm
- T-2.5.3: Content moderation
- T-3.4.3: Cultural name parsing
- T-4.3.1: Backup service
- T-4.3.2: Automated DB dumps
- T-4.4.1: Generic integration service

**Why**
These tasks were already fully implemented in commit `2336238` but the `docs/todo.md` file was not updated to reflect their completion. As per the `AGENTS.md` guidelines, I have marked them as completed `[x]` and explicitly noted that they were `(Implemented in 2336238)`.

**Verification**
Verified that the tests across the codebase continue to pass and no regressions were introduced.

**Result**
The `docs/todo.md` file now accurately reflects the current state of the codebase.

---
*PR created automatically by Jules for task [8602793742125139449](https://jules.google.com/task/8602793742125139449) started by @chifamba*