### PR TITLE
feat: implement DNA provider API stubs and db operations

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Implemented in da173cd)
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -418,3 +418,80 @@ func (r *neo4jRepository) ListRelationshipsByTree(ctx context.Context, treeID st
 	}
 	return result.([]models.Relationship), nil
 }
+
+func (r *neo4jRepository) LinkDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})
+			CREATE (d:DNATest {
+				id: $id,
+				provider: $provider,
+				test_type: $test_type,
+				kit_id: $kit_id,
+				result_url: $result_url,
+				haplogroup_p: $haplogroup_p,
+				haplogroup_m: $haplogroup_m,
+				raw_data_s3_key: $raw_data_s3_key,
+				created_at: $created_at
+			})
+			CREATE (p)-[:HAS_DNA_TEST]->(d)
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"person_id":       personID.String(),
+			"id":              test.ID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+			"created_at":      test.CreatedAt.Format(time.RFC3339),
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}
+
+func (r *neo4jRepository) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `MATCH (p:Person {id: $person_id})-[:HAS_DNA_TEST]->(d:DNATest) RETURN d`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"person_id": personID.String()})
+		if err != nil {
+			return nil, err
+		}
+		var tests []models.DNATest
+		for res.Next(ctx) {
+			node := res.Record().Values[0].(neo4j.Node)
+			props := node.Props
+			id, _ := uuid.Parse(props["id"].(string))
+			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
+
+			tests = append(tests, models.DNATest{
+				ID:             id,
+				PersonID:       personID,
+				Provider:       props["provider"].(string),
+				TestType:       props["test_type"].(string),
+				KitID:          props["kit_id"].(string),
+				ResultURL:      props["result_url"].(string),
+				HaplogroupP:    props["haplogroup_p"].(string),
+				HaplogroupM:    props["haplogroup_m"].(string),
+				RawDataS3Key:   props["raw_data_s3_key"].(string),
+				CreatedAt:      createdAt,
+			})
+		}
+		return tests, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]models.DNATest), nil
+}

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -25,4 +25,8 @@ type Repository interface {
 	DeleteRelationship(ctx context.Context, p1, p2 uuid.UUID, relType string) error
 	CheckCircularReference(ctx context.Context, p1, p2 uuid.UUID, relType string) (bool, error)
 	ListRelationshipsByTree(ctx context.Context, treeID string) ([]models.Relationship, error)
+
+	// DNA operations
+	LinkDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error
+	GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error)
 }

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -27,17 +27,18 @@ func (s *dnaService) LinkDNATest(ctx context.Context, personID uuid.UUID, test *
 	test.ID = uuid.New()
 	test.PersonID = personID
 	test.CreatedAt = time.Now()
-	// In a real implementation, this would save to Neo4j or Postgres
-	// For now, it's a stub that might just log
-	return nil
+
+	return s.repo.LinkDNATest(ctx, personID, test)
 }
 
 func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
-	// Stub
-	return []models.DNATest{}, nil
+	return s.repo.GetDNATests(ctx, personID)
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
+	// Simulated sync with provider. In a full implementation, this would use the
+	// integration service to fetch records based on the provider of the test.
+	// For now, it represents a successful "mock" sync.
+	time.Sleep(100 * time.Millisecond) // Simulate network delay
 	return nil
 }

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -201,11 +201,24 @@ func (p *ancestryProvider) Name() string { return "Ancestry" }
 
 func (p *ancestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("Ancestry: fetching data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "person", "given_name": "John", "surname": "Doe", "birth_date": "1950"},
+		},
+	}, nil
 }
 
 func (p *ancestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type:      "PERSON",
+			GivenName: fmt.Sprint(raw["given_name"]),
+			Surname:   fmt.Sprint(raw["surname"]),
+			BirthDate: fmt.Sprint(raw["birth_date"]),
+		})
+	}
+	return records, nil
 }
 
 // dna23AndMeProvider is a stub for 23andMe DNA provider.
@@ -244,11 +257,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match 1", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +286,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match 1", "shared_cm": 120, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationService_ListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	assert.Len(t, providers, 5)
+
+	names := make(map[string]bool)
+	for _, p := range providers {
+		names[p.Name] = true
+	}
+
+	assert.True(t, names["FamilySearch"])
+	assert.True(t, names["Ancestry"])
+	assert.True(t, names["23andMe"])
+	assert.True(t, names["AncestryDNA"])
+	assert.True(t, names["FTDNA"])
+}
+
+func TestIntegrationService_SyncExternalData_FamilySearch(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+	config := map[string]string{"api_key": "dummy"}
+
+	result, err := svc.SyncExternalData(ctx, "FamilySearch", config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "FamilySearch", result.Provider)
+	assert.Equal(t, 1, result.RecordsFetched)
+	assert.Equal(t, 1, result.RecordsMapped)
+}
+
+func TestIntegrationService_SyncExternalData_Ancestry(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+	config := map[string]string{"api_key": "dummy"}
+
+	result, err := svc.SyncExternalData(ctx, "Ancestry", config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Ancestry", result.Provider)
+	assert.Equal(t, 1, result.RecordsFetched)
+	assert.Equal(t, 1, result.RecordsMapped)
+}
+
+func TestIntegrationService_SyncExternalData_23andMe(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+	config := map[string]string{"api_key": "dummy"}
+
+	result, err := svc.SyncExternalData(ctx, "23andMe", config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "23andMe", result.Provider)
+	assert.Equal(t, 1, result.RecordsFetched)
+	assert.Equal(t, 1, result.RecordsMapped)
+}
+
+func TestIntegrationService_SyncExternalData_AncestryDNA(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+	config := map[string]string{"api_key": "dummy"}
+
+	result, err := svc.SyncExternalData(ctx, "AncestryDNA", config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "AncestryDNA", result.Provider)
+	assert.Equal(t, 1, result.RecordsFetched)
+	assert.Equal(t, 1, result.RecordsMapped)
+}
+
+func TestIntegrationService_SyncExternalData_FTDNA(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+	config := map[string]string{"api_key": "dummy"}
+
+	result, err := svc.SyncExternalData(ctx, "FTDNA", config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "FTDNA", result.Provider)
+	assert.Equal(t, 1, result.RecordsFetched)
+	assert.Equal(t, 1, result.RecordsMapped)
+}
+
+func TestIntegrationService_SyncExternalData_UnknownProvider(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+	config := map[string]string{"api_key": "dummy"}
+
+	_, err := svc.SyncExternalData(ctx, "Unknown", config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown provider")
+}


### PR DESCRIPTION
What:
Implemented DNA provider API stubs across the integration service and updated the genealogy service to support storing/retrieving DNA test data. Replaced previous `nil`/empty array returns with functional mock data representing matches (e.g. `Ancestry Match 1` and `FTDNA Match 1`). Added a robust test suite for the integration service providers.

Why:
Addresses missing task T-4.1.2 in `docs/todo.md` and provides the structural foundation required for downstream DNA processing, match rendering, and verification logic.

Verification:
- Confirmed integration service mock API stubs via `go test` in `services/integration_service/`.
- Confirmed Neo4j queries syntactically correct and compiling in `services/genealogy_service/`.
- Verified all codebase Go tests compile via loop runner.

---
*PR created automatically by Jules for task [14373577077349781777](https://jules.google.com/task/14373577077349781777) started by @chifamba*