### PR TITLE
feat: implement DNA provider API stubs (T-4.1.2)

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Implemented in this commit)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -228,6 +228,7 @@ func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord
 		records = append(records, InternalRecord{
 			Type: "PERSON",
 			Extra: map[string]interface{}{
+				"provider":       "23andMe",
 				"dna_match_name": raw["name"],
 				"shared_cm":      raw["shared_cm"],
 				"confidence":     raw["confidence"],
@@ -244,11 +245,41 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{
+				"type":        "dna_match",
+				"match_name":  "Ancestry Match 1",
+				"shared_cm":   245,
+				"segments":    12,
+				"tree_status": "public",
+			},
+			{
+				"type":        "dna_match",
+				"match_name":  "Ancestry Match 2",
+				"shared_cm":   110,
+				"segments":    6,
+				"tree_status": "unlinked",
+			},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"provider":       "AncestryDNA",
+				"dna_match_name": raw["match_name"],
+				"shared_cm":      raw["shared_cm"],
+				"segments":       raw["segments"],
+				"tree_status":    raw["tree_status"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +289,32 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{
+				"type":            "dna_match",
+				"match_name":      "FTDNA Match 1",
+				"shared_cm":       310,
+				"y_dna_haplogroup": "R-M269",
+				"mt_dna_haplogroup": "H1",
+			},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"provider":          "FTDNA",
+				"dna_match_name":    raw["match_name"],
+				"shared_cm":         raw["shared_cm"],
+				"y_dna_haplogroup":  raw["y_dna_haplogroup"],
+				"mt_dna_haplogroup": raw["mt_dna_haplogroup"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncExternalData_DNAProviders(t *testing.T) {
+	svc := NewIntegrationService().(*integrationService)
+	ctx := context.Background()
+	config := map[string]string{}
+
+	providersToTest := []struct {
+		name          string
+		expectedCount int
+		expectedType  string
+		checkRecord   func(*testing.T, InternalRecord)
+	}{
+		{
+			name:          "23andMe",
+			expectedCount: 1,
+			expectedType:  "PERSON",
+			checkRecord: func(t *testing.T, rec InternalRecord) {
+				assert.Equal(t, "23andMe", rec.Extra["provider"])
+				assert.Equal(t, "DNA Match", rec.Extra["dna_match_name"])
+				assert.Equal(t, 150, rec.Extra["shared_cm"])
+				assert.Equal(t, 0.85, rec.Extra["confidence"])
+			},
+		},
+		{
+			name:          "AncestryDNA",
+			expectedCount: 2,
+			expectedType:  "PERSON",
+			checkRecord: func(t *testing.T, rec InternalRecord) {
+				assert.Equal(t, "AncestryDNA", rec.Extra["provider"])
+				// Match 1 or 2 based on shared_cm
+				if shared, ok := rec.Extra["shared_cm"].(int); ok && shared == 245 {
+					assert.Equal(t, "Ancestry Match 1", rec.Extra["dna_match_name"])
+					assert.Equal(t, 12, rec.Extra["segments"])
+					assert.Equal(t, "public", rec.Extra["tree_status"])
+				} else if ok && shared == 110 {
+					assert.Equal(t, "Ancestry Match 2", rec.Extra["dna_match_name"])
+					assert.Equal(t, 6, rec.Extra["segments"])
+					assert.Equal(t, "unlinked", rec.Extra["tree_status"])
+				} else {
+					t.Fatalf("unexpected shared_cm: %v", rec.Extra["shared_cm"])
+				}
+			},
+		},
+		{
+			name:          "FTDNA",
+			expectedCount: 1,
+			expectedType:  "PERSON",
+			checkRecord: func(t *testing.T, rec InternalRecord) {
+				assert.Equal(t, "FTDNA", rec.Extra["provider"])
+				assert.Equal(t, "FTDNA Match 1", rec.Extra["dna_match_name"])
+				assert.Equal(t, 310, rec.Extra["shared_cm"])
+				assert.Equal(t, "R-M269", rec.Extra["y_dna_haplogroup"])
+				assert.Equal(t, "H1", rec.Extra["mt_dna_haplogroup"])
+			},
+		},
+	}
+
+	for _, tt := range providersToTest {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test top-level sync call for counts
+			result, err := svc.SyncExternalData(ctx, tt.name, config)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.name, result.Provider)
+			assert.Equal(t, tt.expectedCount, result.RecordsFetched)
+			assert.Equal(t, tt.expectedCount, result.RecordsMapped)
+
+			// Now test the underlying provider logic to ensure MapToInternal is working correctly
+			provider := svc.providers[strings.ToLower(tt.name)]
+			require.NotNil(t, provider)
+
+			data, err := provider.FetchData(ctx, config)
+			require.NoError(t, err)
+
+			records, err := provider.MapToInternal(data)
+			require.NoError(t, err)
+			require.Len(t, records, tt.expectedCount)
+
+			for _, rec := range records {
+				assert.Equal(t, tt.expectedType, rec.Type)
+				tt.checkRecord(t, rec)
+			}
+		})
+	}
+}


### PR DESCRIPTION
What: Implemented DNA provider API stubs in `integration_service`. Functional mock data and mapping was implemented for AncestryDNA and FTDNA providers to output realistic DNA matches with shared cM, segments, haplogroups, etc.
Why: Satisfy task T-4.1.2 in `docs/todo.md`.
Result: The `SyncExternalData` process correctly maps the mock DNA data into InternalRecords. Added robust testing suite passing successfully locally and across the repository via CI loop.

---
*PR created automatically by Jules for task [14515376414942470124](https://jules.google.com/task/14515376414942470124) started by @chifamba*