### PR TITLE
feat: implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Implemented in da173cd)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -228,6 +228,7 @@ func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord
 		records = append(records, InternalRecord{
 			Type: "PERSON",
 			Extra: map[string]interface{}{
+				"provider":       p.Name(),
 				"dna_match_name": raw["name"],
 				"shared_cm":      raw["shared_cm"],
 				"confidence":     raw["confidence"],
@@ -244,11 +245,27 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"provider":       p.Name(),
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +275,25 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"provider":       p.Name(),
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,49 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chifamba/dzinza/services/integration_service/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationService_SyncExternalData_DNAProviders(t *testing.T) {
+	svc := service.NewIntegrationService()
+	ctx := context.Background()
+	config := map[string]string{"dummy": "config"}
+
+	tests := []struct {
+		name     string
+		provider string
+	}{
+		{
+			name:     "23andMe Provider",
+			provider: "23andMe",
+		},
+		{
+			name:     "AncestryDNA Provider",
+			provider: "AncestryDNA",
+		},
+		{
+			name:     "FTDNA Provider",
+			provider: "FTDNA",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test the service sync result
+			result, err := svc.SyncExternalData(ctx, tc.provider, config)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.provider, result.Provider)
+			assert.Equal(t, 1, result.RecordsFetched)
+			assert.Equal(t, 1, result.RecordsMapped)
+			assert.Empty(t, result.Errors)
+			assert.False(t, result.SyncedAt.IsZero())
+			assert.True(t, result.Duration >= 0)
+		})
+	}
+}


### PR DESCRIPTION
This pull request fully implements task T-4.1.2 by providing functional mock data responses for the DNA provider stubs (AncestryDNA and FTDNA) and enhancing the MapToInternal functions for all DNA providers to include the provider name in their results. Unit tests have also been added to verify this functionality.

---
*PR created automatically by Jules for task [4589540961140642483](https://jules.google.com/task/4589540961140642483) started by @chifamba*