### PR TITLE
feat: Implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/cmd/main.go
+++ b/services/genealogy_service/cmd/main.go
@@ -53,7 +53,8 @@ func main() {
 	// Initialize layers
 	repo := repository.NewNeo4jRepository(driver)
 	svc := service.NewGenealogyService(repo, eventBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	r := gin.New()
 	r.Use(gin.Recovery())

--- a/services/genealogy_service/internal/handlers/genealogy_handler.go
+++ b/services/genealogy_service/internal/handlers/genealogy_handler.go
@@ -12,11 +12,15 @@ import (
 )
 
 type GenealogyHandler struct {
-	svc service.Service
+	svc        service.Service
+	dnaService service.DNAService
 }
 
-func NewGenealogyHandler(svc service.Service) *GenealogyHandler {
-	return &GenealogyHandler{svc: svc}
+func NewGenealogyHandler(svc service.Service, dnaSvc service.DNAService) *GenealogyHandler {
+	return &GenealogyHandler{
+		svc:        svc,
+		dnaService: dnaSvc,
+	}
 }
 
 func (h *GenealogyHandler) CreateTree(c *gin.Context) {
@@ -215,4 +219,95 @@ func (h *GenealogyHandler) ExportGEDCOM(c *gin.Context) {
 	c.Header("Content-Disposition", "attachment; filename=tree.ged")
 	c.Header("Content-Type", "application/octet-stream")
 	c.Data(http.StatusOK, "application/octet-stream", data)
+}
+
+// DNA Endpoints
+
+// LinkDNATest godoc
+// @Summary Link a DNA test to a person
+// @Description Adds a new DNA test record to a person
+// @Tags dna
+// @Accept json
+// @Produce json
+// @Param id path string true "Person ID"
+// @Param test body models.DNATest true "DNA Test Info"
+// @Success 201 {object} models.DNATest
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
+// @Router /api/v1/dna/persons/{id}/tests [post]
+func (h *GenealogyHandler) LinkDNATest(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "Invalid person ID")
+		return
+	}
+
+	var test models.DNATest
+	if err := c.ShouldBindJSON(&test); err != nil {
+		response.Error(c, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	err = h.dnaService.LinkDNATest(c.Request.Context(), personID, &test)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "Failed to link DNA test")
+		return
+	}
+
+	response.Created(c, test)
+}
+
+// GetDNATests godoc
+// @Summary Get DNA tests for a person
+// @Description Retrieves all DNA tests linked to a person
+// @Tags dna
+// @Produce json
+// @Param id path string true "Person ID"
+// @Success 200 {object} []models.DNATest
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
+// @Router /api/v1/dna/persons/{id}/tests [get]
+func (h *GenealogyHandler) GetDNATests(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "Invalid person ID")
+		return
+	}
+
+	tests, err := h.dnaService.GetDNATests(c.Request.Context(), personID)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "Failed to retrieve DNA tests")
+		return
+	}
+
+	response.Success(c, tests)
+}
+
+// SyncDNATest godoc
+// @Summary Sync DNA test with provider
+// @Description Fetches latest data from the DNA provider API (stub)
+// @Tags dna
+// @Produce json
+// @Param id path string true "Test ID"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
+// @Router /api/v1/dna/tests/{id}/sync [post]
+func (h *GenealogyHandler) SyncDNATest(c *gin.Context) {
+	testIDStr := c.Param("id")
+	testID, err := uuid.Parse(testIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "Invalid test ID")
+		return
+	}
+
+	err = h.dnaService.SyncWithProvider(c.Request.Context(), testID)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "Failed to sync with provider: "+err.Error())
+		return
+	}
+
+	response.Success(c, gin.H{"message": "DNA test synchronized successfully"})
 }

--- a/services/genealogy_service/internal/handlers/routes.go
+++ b/services/genealogy_service/internal/handlers/routes.go
@@ -33,5 +33,13 @@ func RegisterRoutes(r *gin.Engine, h *GenealogyHandler, jwtSecret string) {
 
 		// Relationship management
 		api.POST("/relationships", h.CreateRelationship)
+
+		// DNA management
+		dna := api.Group("/dna")
+		{
+			dna.POST("/persons/:id/tests", h.LinkDNATest)
+			dna.GET("/persons/:id/tests", h.GetDNATests)
+			dna.POST("/tests/:id/sync", h.SyncDNATest)
+		}
 	}
 }

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -418,3 +418,192 @@ func (r *neo4jRepository) ListRelationshipsByTree(ctx context.Context, treeID st
 	}
 	return result.([]models.Relationship), nil
 }
+
+func (r *neo4jRepository) CreateDNATest(ctx context.Context, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})
+			CREATE (d:DNATest {
+				id: $id,
+				person_id: $person_id,
+				provider: $provider,
+				test_type: $test_type,
+				kit_id: $kit_id,
+				result_url: $result_url,
+				haplogroup_p: $haplogroup_p,
+				haplogroup_m: $haplogroup_m,
+				raw_data_s3_key: $raw_data_s3_key,
+				created_at: $created_at
+			})
+			CREATE (p)-[:HAS_DNA_TEST]->(d)
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"person_id":       test.PersonID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+			"created_at":      test.CreatedAt.Format(time.RFC3339),
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}
+
+func (r *neo4jRepository) GetDNATestsByPersonID(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `MATCH (p:Person {id: $person_id})-[:HAS_DNA_TEST]->(d:DNATest) RETURN d`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"person_id": personID.String()})
+		if err != nil {
+			return nil, err
+		}
+
+		var tests []models.DNATest
+		for res.Next(ctx) {
+			record := res.Record()
+			node, ok := record.Values[0].(neo4j.Node)
+			if !ok {
+				continue
+			}
+
+			props := node.Props
+			id, _ := uuid.Parse(props["id"].(string))
+			pID, _ := uuid.Parse(props["person_id"].(string))
+
+			createdAtStr, _ := props["created_at"].(string)
+			createdAt, _ := time.Parse(time.RFC3339, createdAtStr)
+
+			provider, _ := props["provider"].(string)
+			testType, _ := props["test_type"].(string)
+			kitID, _ := props["kit_id"].(string)
+			resultURL, _ := props["result_url"].(string)
+			haplogroupP, _ := props["haplogroup_p"].(string)
+			haplogroupM, _ := props["haplogroup_m"].(string)
+			rawDataS3Key, _ := props["raw_data_s3_key"].(string)
+
+			test := models.DNATest{
+				ID:             id,
+				PersonID:       pID,
+				Provider:       provider,
+				TestType:       testType,
+				KitID:          kitID,
+				ResultURL:      resultURL,
+				HaplogroupP:    haplogroupP,
+				HaplogroupM:    haplogroupM,
+				RawDataS3Key:   rawDataS3Key,
+				CreatedAt:      createdAt,
+			}
+			tests = append(tests, test)
+		}
+		if err = res.Err(); err != nil {
+			return nil, err
+		}
+		return tests, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]models.DNATest), nil
+}
+
+func (r *neo4jRepository) GetDNATestByID(ctx context.Context, id uuid.UUID) (*models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `MATCH (d:DNATest {id: $id}) RETURN d`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"id": id.String()})
+		if err != nil {
+			return nil, err
+		}
+
+		if res.Next(ctx) {
+			record := res.Record()
+			node, ok := record.Values[0].(neo4j.Node)
+			if !ok {
+				return nil, fmt.Errorf("unexpected node type")
+			}
+
+			props := node.Props
+			testID, _ := uuid.Parse(props["id"].(string))
+			pID, _ := uuid.Parse(props["person_id"].(string))
+
+			createdAtStr, _ := props["created_at"].(string)
+			createdAt, _ := time.Parse(time.RFC3339, createdAtStr)
+
+			provider, _ := props["provider"].(string)
+			testType, _ := props["test_type"].(string)
+			kitID, _ := props["kit_id"].(string)
+			resultURL, _ := props["result_url"].(string)
+			haplogroupP, _ := props["haplogroup_p"].(string)
+			haplogroupM, _ := props["haplogroup_m"].(string)
+			rawDataS3Key, _ := props["raw_data_s3_key"].(string)
+
+			test := &models.DNATest{
+				ID:             testID,
+				PersonID:       pID,
+				Provider:       provider,
+				TestType:       testType,
+				KitID:          kitID,
+				ResultURL:      resultURL,
+				HaplogroupP:    haplogroupP,
+				HaplogroupM:    haplogroupM,
+				RawDataS3Key:   rawDataS3Key,
+				CreatedAt:      createdAt,
+			}
+			return test, nil
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return result.(*models.DNATest), nil
+}
+
+func (r *neo4jRepository) UpdateDNATest(ctx context.Context, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (d:DNATest {id: $id})
+			SET d.provider = $provider,
+				d.test_type = $test_type,
+				d.kit_id = $kit_id,
+				d.result_url = $result_url,
+				d.haplogroup_p = $haplogroup_p,
+				d.haplogroup_m = $haplogroup_m,
+				d.raw_data_s3_key = $raw_data_s3_key
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -25,4 +25,10 @@ type Repository interface {
 	DeleteRelationship(ctx context.Context, p1, p2 uuid.UUID, relType string) error
 	CheckCircularReference(ctx context.Context, p1, p2 uuid.UUID, relType string) (bool, error)
 	ListRelationshipsByTree(ctx context.Context, treeID string) ([]models.Relationship, error)
+
+	// DNA operations
+	CreateDNATest(ctx context.Context, test *models.DNATest) error
+	GetDNATestsByPersonID(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error)
+	GetDNATestByID(ctx context.Context, id uuid.UUID) (*models.DNATest, error)
+	UpdateDNATest(ctx context.Context, test *models.DNATest) error
 }

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/models"
@@ -26,18 +27,46 @@ func NewDNAService(repo repository.Repository) DNAService {
 func (s *dnaService) LinkDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error {
 	test.ID = uuid.New()
 	test.PersonID = personID
-	test.CreatedAt = time.Now()
-	// In a real implementation, this would save to Neo4j or Postgres
-	// For now, it's a stub that might just log
-	return nil
+	if test.CreatedAt.IsZero() {
+		test.CreatedAt = time.Now()
+	}
+	return s.repo.CreateDNATest(ctx, test)
 }
 
 func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
-	// Stub
-	return []models.DNATest{}, nil
+	return s.repo.GetDNATestsByPersonID(ctx, personID)
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
-	return nil
+	// 1. Get the existing test from the repository
+	test, err := s.repo.GetDNATestByID(ctx, testID)
+	if err != nil {
+		return err
+	}
+	if test == nil {
+		return fmt.Errorf("DNA test not found")
+	}
+
+	// 2. Fetch data from external provider (Stub implementation)
+	// In a real scenario, this would involve calling the provider's API.
+	// For now, we simulate by updating some mock data based on the provider.
+	switch test.Provider {
+	case "Ancestry":
+		test.HaplogroupP = "R-M269"
+		test.HaplogroupM = "H1"
+		test.ResultURL = "https://ancestry.com/dna/results/" + test.KitID
+	case "23andMe":
+		test.HaplogroupP = "E-M96"
+		test.HaplogroupM = "L3"
+		test.ResultURL = "https://you.23andme.com/reports/" + test.KitID
+	case "MyHeritage":
+		test.HaplogroupP = "J-M267"
+		test.HaplogroupM = "U5"
+		test.ResultURL = "https://myheritage.com/dna/" + test.KitID
+	default:
+		// Unknown provider, do nothing
+	}
+
+	// 3. Update the record in the database
+	return s.repo.UpdateDNATest(ctx, test)
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -56,7 +56,8 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	repo := repository.NewNeo4jRepository(driver)
 	mockBus := &mockEventBus{} // or implement a simple mock
 	svc := service.NewGenealogyService(repo, mockBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()


### PR DESCRIPTION
Implemented the DNA provider API stub logic.
- Repository: Added DNA operations to Neo4j logic.
- Service: Added logic to stub fetching and synchronizing data with Ancestry, 23andMe, and MyHeritage by mocking the haplogroup and URL.
- Handlers: Implemented routes to link a test, list a person's tests, and sync tests with a provider.
- Config/DI: Wired the new DNAService dependency in `main.go` and integration tests.
- Todo: Marked T-4.1.2 as complete.

---
*PR created automatically by Jules for task [6438414235470090325](https://jules.google.com/task/6438414235470090325) started by @chifamba*