### PR TITLE
feat: implement DNA provider API stubs and backend endpoints

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/cmd/main.go
+++ b/services/genealogy_service/cmd/main.go
@@ -53,7 +53,8 @@ func main() {
 	// Initialize layers
 	repo := repository.NewNeo4jRepository(driver)
 	svc := service.NewGenealogyService(repo, eventBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	r := gin.New()
 	r.Use(gin.Recovery())

--- a/services/genealogy_service/internal/handlers/genealogy_handler.go
+++ b/services/genealogy_service/internal/handlers/genealogy_handler.go
@@ -12,11 +12,51 @@ import (
 )
 
 type GenealogyHandler struct {
-	svc service.Service
+	svc    service.Service
+	dnaSvc service.DNAService
 }
 
-func NewGenealogyHandler(svc service.Service) *GenealogyHandler {
-	return &GenealogyHandler{svc: svc}
+func NewGenealogyHandler(svc service.Service, dnaSvc service.DNAService) *GenealogyHandler {
+	return &GenealogyHandler{svc: svc, dnaSvc: dnaSvc}
+}
+
+func (h *GenealogyHandler) AddDNATest(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person id")
+		return
+	}
+
+	var test models.DNATest
+	if err := c.ShouldBindJSON(&test); err != nil {
+		response.Error(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.dnaSvc.LinkDNATest(c.Request.Context(), personID, &test); err != nil {
+		response.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	response.Success(c, test)
+}
+
+func (h *GenealogyHandler) GetDNATests(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person id")
+		return
+	}
+
+	tests, err := h.dnaSvc.GetDNATests(c.Request.Context(), personID)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	response.Success(c, tests)
 }
 
 func (h *GenealogyHandler) CreateTree(c *gin.Context) {

--- a/services/genealogy_service/internal/handlers/routes.go
+++ b/services/genealogy_service/internal/handlers/routes.go
@@ -29,6 +29,10 @@ func RegisterRoutes(r *gin.Engine, h *GenealogyHandler, jwtSecret string) {
 			persons.GET("/:id", h.GetPerson)
 			persons.PUT("/:id", h.UpdatePerson)
 			persons.DELETE("/:id", h.DeletePerson)
+
+			// DNA tests
+			persons.POST("/:id/dna", h.AddDNATest)
+			persons.GET("/:id/dna", h.GetDNATests)
 		}
 
 		// Relationship management

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -418,3 +418,84 @@ func (r *neo4jRepository) ListRelationshipsByTree(ctx context.Context, treeID st
 	}
 	return result.([]models.Relationship), nil
 }
+
+func (r *neo4jRepository) CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})
+			CREATE (d:DNATest {
+				id: $id,
+				provider: $provider,
+				test_type: $test_type,
+				kit_id: $kit_id,
+				result_url: $result_url,
+				haplogroup_p: $haplogroup_p,
+				haplogroup_m: $haplogroup_m,
+				raw_data_s3_key: $raw_data_s3_key,
+				created_at: $created_at
+			})
+			CREATE (p)-[:HAS_DNA_TEST]->(d)
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"person_id":       personID.String(),
+			"id":              test.ID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+			"created_at":      test.CreatedAt.Format(time.RFC3339),
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}
+
+func (r *neo4jRepository) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})-[:HAS_DNA_TEST]->(d:DNATest)
+			RETURN d
+		`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"person_id": personID.String()})
+		if err != nil {
+			return nil, err
+		}
+		var tests []models.DNATest
+		for res.Next(ctx) {
+			node := res.Record().Values[0].(neo4j.Node)
+			props := node.Props
+			id, _ := uuid.Parse(props["id"].(string))
+			pID := personID
+			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
+
+			tests = append(tests, models.DNATest{
+				ID:             id,
+				PersonID:       pID,
+				Provider:       props["provider"].(string),
+				TestType:       props["test_type"].(string),
+				KitID:          props["kit_id"].(string),
+				ResultURL:      props["result_url"].(string),
+				HaplogroupP:    props["haplogroup_p"].(string),
+				HaplogroupM:    props["haplogroup_m"].(string),
+				RawDataS3Key:   props["raw_data_s3_key"].(string),
+				CreatedAt:      createdAt,
+			})
+		}
+		return tests, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]models.DNATest), nil
+}

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -25,4 +25,8 @@ type Repository interface {
 	DeleteRelationship(ctx context.Context, p1, p2 uuid.UUID, relType string) error
 	CheckCircularReference(ctx context.Context, p1, p2 uuid.UUID, relType string) (bool, error)
 	ListRelationshipsByTree(ctx context.Context, treeID string) ([]models.Relationship, error)
+
+	// DNA operations
+	CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error
+	GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error)
 }

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -27,17 +27,15 @@ func (s *dnaService) LinkDNATest(ctx context.Context, personID uuid.UUID, test *
 	test.ID = uuid.New()
 	test.PersonID = personID
 	test.CreatedAt = time.Now()
-	// In a real implementation, this would save to Neo4j or Postgres
-	// For now, it's a stub that might just log
-	return nil
+	return s.repo.CreateDNATest(ctx, personID, test)
 }
 
 func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
-	// Stub
-	return []models.DNATest{}, nil
+	return s.repo.GetDNATests(ctx, personID)
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
+	// Functional mock for syncing with external provider
+	// In a full implementation, this would trigger integration_service to fetch data via Kafka/REST
 	return nil
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -56,7 +56,8 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	repo := repository.NewNeo4jRepository(driver)
 	mockBus := &mockEventBus{} // or implement a simple mock
 	svc := service.NewGenealogyService(repo, mockBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -244,11 +244,28 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match 1", "shared_cm": 200, "confidence": 0.90},
+			{"type": "dna_match", "name": "Ancestry Match 2", "shared_cm": 50, "confidence": 0.75},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+				"provider":       "AncestryDNA",
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +275,25 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match 1", "shared_cm": 300, "confidence": 0.95},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+				"provider":       "FTDNA",
+			},
+		})
+	}
+	return records, nil
 }


### PR DESCRIPTION
What:
Implemented DNA provider API stubs (AncestryDNA, FTDNA) in `integration_service` returning mock matches with shared cM and confidence. Implemented backend DNA test persistence in `genealogy_service`, wiring the `DNAService` from the repository layer (storing tests in Neo4j with `HAS_DNA_TEST` relationships) through to the HTTP endpoints.

Why:
To fulfill task T-4.1.2 (Implement DNA provider API stubs) and establish the data layer for DNA integration (Phase 4.1), allowing clients to link DNA tests to persons in the family tree.

Measured Improvement:
N/A (Feature addition)

---
*PR created automatically by Jules for task [475579333452318755](https://jules.google.com/task/475579333452318755) started by @chifamba*