### PR TITLE
feat: Implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/cmd/main.go
+++ b/services/genealogy_service/cmd/main.go
@@ -53,7 +53,8 @@ func main() {
 	// Initialize layers
 	repo := repository.NewNeo4jRepository(driver)
 	svc := service.NewGenealogyService(repo, eventBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	r := gin.New()
 	r.Use(gin.Recovery())

--- a/services/genealogy_service/internal/handlers/genealogy_handler.go
+++ b/services/genealogy_service/internal/handlers/genealogy_handler.go
@@ -12,11 +12,15 @@ import (
 )
 
 type GenealogyHandler struct {
-	svc service.Service
+	svc    service.Service
+	dnaSvc service.DNAService
 }
 
-func NewGenealogyHandler(svc service.Service) *GenealogyHandler {
-	return &GenealogyHandler{svc: svc}
+func NewGenealogyHandler(svc service.Service, dnaSvc service.DNAService) *GenealogyHandler {
+	return &GenealogyHandler{
+		svc:    svc,
+		dnaSvc: dnaSvc,
+	}
 }
 
 func (h *GenealogyHandler) CreateTree(c *gin.Context) {
@@ -215,4 +219,67 @@ func (h *GenealogyHandler) ExportGEDCOM(c *gin.Context) {
 	c.Header("Content-Disposition", "attachment; filename=tree.ged")
 	c.Header("Content-Type", "application/octet-stream")
 	c.Data(http.StatusOK, "application/octet-stream", data)
+}
+
+func (h *GenealogyHandler) LinkDNATest(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person ID")
+		return
+	}
+
+	var req models.LinkDNATestRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	test := &models.DNATest{
+		Provider:     req.Provider,
+		TestType:     req.TestType,
+		KitID:        req.KitID,
+		ResultURL:    req.ResultURL,
+		RawDataS3Key: req.RawDataS3Key,
+	}
+
+	if err := h.dnaSvc.LinkDNATest(c.Request.Context(), id, test); err != nil {
+		response.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, test)
+}
+
+func (h *GenealogyHandler) GetDNATests(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person ID")
+		return
+	}
+
+	tests, err := h.dnaSvc.GetDNATests(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if tests == nil {
+		tests = []models.DNATest{}
+	}
+
+	c.JSON(http.StatusOK, tests)
+}
+
+func (h *GenealogyHandler) SyncDNATestWithProvider(c *gin.Context) {
+	testID, err := uuid.Parse(c.Param("testid"))
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid DNA test ID")
+		return
+	}
+
+	if err := h.dnaSvc.SyncWithProvider(c.Request.Context(), testID); err != nil {
+		response.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "synchronized"})
 }

--- a/services/genealogy_service/internal/handlers/routes.go
+++ b/services/genealogy_service/internal/handlers/routes.go
@@ -29,9 +29,14 @@ func RegisterRoutes(r *gin.Engine, h *GenealogyHandler, jwtSecret string) {
 			persons.GET("/:id", h.GetPerson)
 			persons.PUT("/:id", h.UpdatePerson)
 			persons.DELETE("/:id", h.DeletePerson)
+			persons.POST("/:id/dna", h.LinkDNATest)
+			persons.GET("/:id/dna", h.GetDNATests)
 		}
 
 		// Relationship management
 		api.POST("/relationships", h.CreateRelationship)
+
+		// DNA test syncing
+		api.POST("/dna-tests/:testid/sync", h.SyncDNATestWithProvider)
 	}
 }

--- a/services/genealogy_service/internal/models/dto.go
+++ b/services/genealogy_service/internal/models/dto.go
@@ -28,3 +28,12 @@ type CreateRelationshipRequest struct {
 	Type      string                 `json:"type" binding:"required,oneof=PARENT_OF SPOUSE_OF SIBLING_OF"`
 	Metadata  map[string]interface{} `json:"metadata"`
 }
+
+// LinkDNATestRequest defines the payload for linking a DNA test to a person.
+type LinkDNATestRequest struct {
+	Provider     string `json:"provider" binding:"required"`
+	TestType     string `json:"test_type" binding:"required"`
+	KitID        string `json:"kit_id"`
+	ResultURL    string `json:"result_url"`
+	RawDataS3Key string `json:"raw_data_s3_key"`
+}

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -418,3 +418,170 @@ func (r *neo4jRepository) ListRelationshipsByTree(ctx context.Context, treeID st
 	}
 	return result.([]models.Relationship), nil
 }
+
+func (r *neo4jRepository) CreateDNATest(ctx context.Context, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	res, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})
+			CREATE (d:DNATest {
+				id: $id,
+				person_id: $person_id,
+				provider: $provider,
+				test_type: $test_type,
+				kit_id: $kit_id,
+				result_url: $result_url,
+				haplogroup_p: $haplogroup_p,
+				haplogroup_m: $haplogroup_m,
+				raw_data_s3_key: $raw_data_s3_key,
+				created_at: $created_at
+			})
+			CREATE (p)-[:HAS_DNA_TEST]->(d)
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"person_id":       test.PersonID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+			"created_at":      test.CreatedAt.Format(time.RFC3339),
+		}
+		res, err := tx.Run(ctx, query, params)
+		if err != nil {
+			return nil, err
+		}
+		if res.Next(ctx) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	if !res.(bool) {
+		return fmt.Errorf("person with id %s not found", test.PersonID)
+	}
+	return nil
+}
+
+func (r *neo4jRepository) GetDNATestsByPerson(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})-[:HAS_DNA_TEST]->(d:DNATest)
+			RETURN d
+		`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"person_id": personID.String()})
+		if err != nil {
+			return nil, err
+		}
+		var tests []models.DNATest
+		for res.Next(ctx) {
+			node := res.Record().Values[0].(neo4j.Node)
+			props := node.Props
+			id, _ := uuid.Parse(props["id"].(string))
+			pID, _ := uuid.Parse(props["person_id"].(string))
+			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
+
+			tests = append(tests, models.DNATest{
+				ID:             id,
+				PersonID:       pID,
+				Provider:       props["provider"].(string),
+				TestType:       props["test_type"].(string),
+				KitID:          props["kit_id"].(string),
+				ResultURL:      props["result_url"].(string),
+				HaplogroupP:    props["haplogroup_p"].(string),
+				HaplogroupM:    props["haplogroup_m"].(string),
+				RawDataS3Key:   props["raw_data_s3_key"].(string),
+				CreatedAt:      createdAt,
+			})
+		}
+		return tests, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]models.DNATest), nil
+}
+
+func (r *neo4jRepository) GetDNATestByID(ctx context.Context, id uuid.UUID) (*models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `MATCH (d:DNATest {id: $id}) RETURN d`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"id": id.String()})
+		if err != nil {
+			return nil, err
+		}
+		if res.Next(ctx) {
+			node := res.Record().Values[0].(neo4j.Node)
+			props := node.Props
+			dID, _ := uuid.Parse(props["id"].(string))
+			pID, _ := uuid.Parse(props["person_id"].(string))
+			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
+
+			return &models.DNATest{
+				ID:             dID,
+				PersonID:       pID,
+				Provider:       props["provider"].(string),
+				TestType:       props["test_type"].(string),
+				KitID:          props["kit_id"].(string),
+				ResultURL:      props["result_url"].(string),
+				HaplogroupP:    props["haplogroup_p"].(string),
+				HaplogroupM:    props["haplogroup_m"].(string),
+				RawDataS3Key:   props["raw_data_s3_key"].(string),
+				CreatedAt:      createdAt,
+			}, nil
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return result.(*models.DNATest), nil
+}
+
+func (r *neo4jRepository) UpdateDNATest(ctx context.Context, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (d:DNATest {id: $id})
+			SET d.provider = $provider,
+				d.test_type = $test_type,
+				d.kit_id = $kit_id,
+				d.result_url = $result_url,
+				d.haplogroup_p = $haplogroup_p,
+				d.haplogroup_m = $haplogroup_m,
+				d.raw_data_s3_key = $raw_data_s3_key
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -25,4 +25,10 @@ type Repository interface {
 	DeleteRelationship(ctx context.Context, p1, p2 uuid.UUID, relType string) error
 	CheckCircularReference(ctx context.Context, p1, p2 uuid.UUID, relType string) (bool, error)
 	ListRelationshipsByTree(ctx context.Context, treeID string) ([]models.Relationship, error)
+
+	// DNA Test operations
+	CreateDNATest(ctx context.Context, test *models.DNATest) error
+	GetDNATestsByPerson(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error)
+	GetDNATestByID(ctx context.Context, id uuid.UUID) (*models.DNATest, error)
+	UpdateDNATest(ctx context.Context, test *models.DNATest) error
 }

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/chifamba/dzinza/services/genealogy_service/internal/models"
@@ -27,17 +28,26 @@ func (s *dnaService) LinkDNATest(ctx context.Context, personID uuid.UUID, test *
 	test.ID = uuid.New()
 	test.PersonID = personID
 	test.CreatedAt = time.Now()
-	// In a real implementation, this would save to Neo4j or Postgres
-	// For now, it's a stub that might just log
-	return nil
+
+	return s.repo.CreateDNATest(ctx, test)
 }
 
 func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
-	// Stub
-	return []models.DNATest{}, nil
+	return s.repo.GetDNATestsByPerson(ctx, personID)
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
-	return nil
+	test, err := s.repo.GetDNATestByID(ctx, testID)
+	if err != nil {
+		return err
+	}
+	if test == nil {
+		return fmt.Errorf("DNA test with id %s not found", testID)
+	}
+
+	// Mocking integration with external providers to retrieve haplogroup data
+	test.HaplogroupP = "R-M269"
+	test.HaplogroupM = "H1a"
+
+	return s.repo.UpdateDNATest(ctx, test)
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -56,7 +56,8 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	repo := repository.NewNeo4jRepository(driver)
 	mockBus := &mockEventBus{} // or implement a simple mock
 	svc := service.NewGenealogyService(repo, mockBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()


### PR DESCRIPTION
Implemented DNA test provider stubs for `genealogy_service` resolving T-4.1.2.
- Created repository queries to fetch and update `[:HAS_DNA_TEST]` Neo4j entities.
- Implemented handler methods `LinkDNATest`, `GetDNATests`, and `SyncDNATestWithProvider`.
- Connected routes and structured mock handler.
- Updated `docs/todo.md`.

---
*PR created automatically by Jules for task [2928046011645542543](https://jules.google.com/task/2928046011645542543) started by @chifamba*