### PR TITLE
feat: Implement DNA provider API stubs (T-4.1.2)

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed) (Implemented)
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/cmd/main.go
+++ b/services/genealogy_service/cmd/main.go
@@ -53,7 +53,8 @@ func main() {
 	// Initialize layers
 	repo := repository.NewNeo4jRepository(driver)
 	svc := service.NewGenealogyService(repo, eventBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	r := gin.New()
 	r.Use(gin.Recovery())

--- a/services/genealogy_service/internal/handlers/genealogy_handler.go
+++ b/services/genealogy_service/internal/handlers/genealogy_handler.go
@@ -12,11 +12,12 @@ import (
 )
 
 type GenealogyHandler struct {
-	svc service.Service
+	svc    service.Service
+	dnaSvc service.DNAService
 }
 
-func NewGenealogyHandler(svc service.Service) *GenealogyHandler {
-	return &GenealogyHandler{svc: svc}
+func NewGenealogyHandler(svc service.Service, dnaSvc service.DNAService) *GenealogyHandler {
+	return &GenealogyHandler{svc: svc, dnaSvc: dnaSvc}
 }
 
 func (h *GenealogyHandler) CreateTree(c *gin.Context) {
@@ -215,4 +216,45 @@ func (h *GenealogyHandler) ExportGEDCOM(c *gin.Context) {
 	c.Header("Content-Disposition", "attachment; filename=tree.ged")
 	c.Header("Content-Type", "application/octet-stream")
 	c.Data(http.StatusOK, "application/octet-stream", data)
+}
+
+// --- DNA Handlers ---
+
+func (h *GenealogyHandler) LinkDNATest(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person id")
+		return
+	}
+
+	var test models.DNATest
+	if err := c.ShouldBindJSON(&test); err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := h.dnaSvc.LinkDNATest(c.Request.Context(), personID, &test); err != nil {
+		response.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	response.Success(c, test)
+}
+
+func (h *GenealogyHandler) GetDNATests(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person id")
+		return
+	}
+
+	tests, err := h.dnaSvc.GetDNATests(c.Request.Context(), personID)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	response.Success(c, tests)
 }

--- a/services/genealogy_service/internal/handlers/routes.go
+++ b/services/genealogy_service/internal/handlers/routes.go
@@ -29,6 +29,10 @@ func RegisterRoutes(r *gin.Engine, h *GenealogyHandler, jwtSecret string) {
 			persons.GET("/:id", h.GetPerson)
 			persons.PUT("/:id", h.UpdatePerson)
 			persons.DELETE("/:id", h.DeletePerson)
+
+			// DNA integration
+			persons.POST("/:id/dna", h.LinkDNATest)
+			persons.GET("/:id/dna", h.GetDNATests)
 		}
 
 		// Relationship management

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -418,3 +418,82 @@ func (r *neo4jRepository) ListRelationshipsByTree(ctx context.Context, treeID st
 	}
 	return result.([]models.Relationship), nil
 }
+
+func (r *neo4jRepository) CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})
+			CREATE (d:DNATest {
+				id: $id,
+				person_id: $person_id,
+				provider: $provider,
+				test_type: $test_type,
+				kit_id: $kit_id,
+				result_url: $result_url,
+				haplogroup_p: $haplogroup_p,
+				haplogroup_m: $haplogroup_m,
+				raw_data_s3_key: $raw_data_s3_key,
+				created_at: $created_at
+			})
+			CREATE (p)-[:HAS_DNA_TEST]->(d)
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"person_id":       personID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+			"created_at":      test.CreatedAt.Format(time.RFC3339),
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}
+
+func (r *neo4jRepository) ListDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `MATCH (p:Person {id: $person_id})-[:HAS_DNA_TEST]->(d:DNATest) RETURN d`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"person_id": personID.String()})
+		if err != nil {
+			return nil, err
+		}
+		var tests []models.DNATest
+		for res.Next(ctx) {
+			node := res.Record().Values[0].(neo4j.Node)
+			props := node.Props
+			id, _ := uuid.Parse(props["id"].(string))
+			pID, _ := uuid.Parse(props["person_id"].(string))
+			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
+
+			tests = append(tests, models.DNATest{
+				ID:             id,
+				PersonID:       pID,
+				Provider:       props["provider"].(string),
+				TestType:       props["test_type"].(string),
+				KitID:          props["kit_id"].(string),
+				ResultURL:      props["result_url"].(string),
+				HaplogroupP:    props["haplogroup_p"].(string),
+				HaplogroupM:    props["haplogroup_m"].(string),
+				RawDataS3Key:   props["raw_data_s3_key"].(string),
+				CreatedAt:      createdAt,
+			})
+		}
+		return tests, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]models.DNATest), nil
+}

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -25,4 +25,8 @@ type Repository interface {
 	DeleteRelationship(ctx context.Context, p1, p2 uuid.UUID, relType string) error
 	CheckCircularReference(ctx context.Context, p1, p2 uuid.UUID, relType string) (bool, error)
 	ListRelationshipsByTree(ctx context.Context, treeID string) ([]models.Relationship, error)
+
+	// DNA operations
+	CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error
+	ListDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error)
 }

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -27,17 +27,21 @@ func (s *dnaService) LinkDNATest(ctx context.Context, personID uuid.UUID, test *
 	test.ID = uuid.New()
 	test.PersonID = personID
 	test.CreatedAt = time.Now()
-	// In a real implementation, this would save to Neo4j or Postgres
-	// For now, it's a stub that might just log
+
+	err := s.repo.CreateDNATest(ctx, personID, test)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
-	// Stub
-	return []models.DNATest{}, nil
+	return s.repo.ListDNATests(ctx, personID)
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
 	// Stub for syncing with Ancestry, 23andMe, etc.
+	// The sync logic would normally fetch the test via its ID, extract credentials or link tokens,
+	// and invoke the integration_service.
 	return nil
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -56,7 +56,8 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	repo := repository.NewNeo4jRepository(driver)
 	mockBus := &mockEventBus{} // or implement a simple mock
 	svc := service.NewGenealogyService(repo, mockBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()


### PR DESCRIPTION
This PR implements the DNA provider API stubs in the `genealogy_service` as part of Phase 4 tasks.

It introduces endpoints to link a DNA test to a person and list DNA tests for a person, backed by a Neo4j repository that creates and queries `DNATest` nodes via a `[:HAS_DNA_TEST]` relationship. The `SyncWithProvider` method is left intentionally as a stub to represent third-party API syncing per the requirements.

All tests have been run and verified.
Auto-merge if there are no conflicts.

---
*PR created automatically by Jules for task [3657883422325686472](https://jules.google.com/task/3657883422325686472) started by @chifamba*