### PR TITLE
feat: implement DNA provider API stubs (T-4.1.2)

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -217,7 +217,9 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 	slog.Info("23andMe: fetching DNA data (stub mode)")
 	return &ProviderData{
 		Records: []map[string]interface{}{
-			{"type": "dna_match", "name": "DNA Match", "shared_cm": 150, "confidence": 0.85},
+			{"type": "dna_match", "name": "Relative A", "shared_cm": 3500, "confidence": 0.99, "relationship": "Parent"},
+			{"type": "dna_match", "name": "Relative B", "shared_cm": 1700, "confidence": 0.95, "relationship": "Sibling"},
+			{"type": "dna_match", "name": "Relative C", "shared_cm": 850, "confidence": 0.90, "relationship": "1st Cousin"},
 		},
 	}, nil
 }
@@ -225,13 +227,25 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = name
+		}
+		if sharedCM, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = sharedCM
+		} else if sharedCM, ok := raw["shared_cm"].(float64); ok { // JSON unmarshals numbers to float64
+			extra["shared_cm"] = sharedCM
+		}
+		if confidence, ok := raw["confidence"].(float64); ok {
+			extra["confidence"] = confidence
+		}
+		if relationship, ok := raw["relationship"].(string); ok {
+			extra["relationship"] = relationship
+		}
+
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +258,47 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "given_name": "John", "surname": "Doe", "shared_segments": 25, "shared_cm": 1200},
+			{"type": "dna_match", "given_name": "Jane", "surname": "Smith", "shared_segments": 10, "shared_cm": 400},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if sharedSegments, ok := raw["shared_segments"].(int); ok {
+			extra["shared_segments"] = sharedSegments
+		} else if sharedSegments, ok := raw["shared_segments"].(float64); ok {
+			extra["shared_segments"] = sharedSegments
+		}
+		if sharedCM, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = sharedCM
+		} else if sharedCM, ok := raw["shared_cm"].(float64); ok {
+			extra["shared_cm"] = sharedCM
+		}
+
+		givenName := ""
+		if gn, ok := raw["given_name"].(string); ok {
+			givenName = gn
+		}
+
+		surname := ""
+		if sn, ok := raw["surname"].(string); ok {
+			surname = sn
+		}
+
+		records = append(records, InternalRecord{
+			Type:      "PERSON",
+			GivenName: givenName,
+			Surname:   surname,
+			Extra:     extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +308,37 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "y_dna_match", "match_name": "Y-DNA Match 1", "genetic_distance": 1, "haplogroup": "R-M269"},
+			{"type": "mt_dna_match", "match_name": "mtDNA Match 1", "genetic_distance": 0, "haplogroup": "H1a"},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if matchName, ok := raw["match_name"].(string); ok {
+			extra["dna_match_name"] = matchName
+		}
+		if geneticDistance, ok := raw["genetic_distance"].(int); ok {
+			extra["genetic_distance"] = geneticDistance
+		} else if geneticDistance, ok := raw["genetic_distance"].(float64); ok {
+			extra["genetic_distance"] = geneticDistance
+		}
+		if haplogroup, ok := raw["haplogroup"].(string); ok {
+			extra["haplogroup"] = haplogroup
+		}
+		if recordType, ok := raw["type"].(string); ok {
+			extra["test_type"] = recordType
+		}
+
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationService_SyncExternalData_23AndMe(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+
+	res, err := svc.SyncExternalData(ctx, "23andme", nil)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, "23andme", res.Provider)
+	assert.Equal(t, 3, res.RecordsFetched)
+	assert.Equal(t, 3, res.RecordsMapped)
+}
+
+func TestIntegrationService_SyncExternalData_AncestryDNA(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+
+	res, err := svc.SyncExternalData(ctx, "ancestrydna", nil)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, "ancestrydna", res.Provider)
+	assert.Equal(t, 2, res.RecordsFetched)
+	assert.Equal(t, 2, res.RecordsMapped)
+}
+
+func TestIntegrationService_SyncExternalData_FTDNA(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+
+	res, err := svc.SyncExternalData(ctx, "ftdna", nil)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, "ftdna", res.Provider)
+	assert.Equal(t, 2, res.RecordsFetched)
+	assert.Equal(t, 2, res.RecordsMapped)
+}
+
+func TestProvider_MapToInternal_23AndMe(t *testing.T) {
+	provider := &dna23AndMeProvider{}
+
+	// Test with explicit types correctly as simulated after JSON unmarshaling
+	data := &ProviderData{
+		Records: []map[string]interface{}{
+			{
+				"type": "dna_match",
+				"name": "Relative A",
+				"shared_cm": float64(3500), // JSON parser parses numbers as float64
+				"confidence": float64(0.99),
+				"relationship": "Parent",
+			},
+		},
+	}
+
+	records, err := provider.MapToInternal(data)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	assert.Equal(t, "PERSON", records[0].Type)
+	assert.Equal(t, "Relative A", records[0].Extra["dna_match_name"])
+	assert.Equal(t, float64(3500), records[0].Extra["shared_cm"])
+	assert.Equal(t, float64(0.99), records[0].Extra["confidence"])
+	assert.Equal(t, "Parent", records[0].Extra["relationship"])
+}
+
+func TestProvider_MapToInternal_AncestryDNA(t *testing.T) {
+	provider := &dnaAncestryProvider{}
+
+	data := &ProviderData{
+		Records: []map[string]interface{}{
+			{
+				"type": "dna_match",
+				"given_name": "John",
+				"surname": "Doe",
+				"shared_segments": float64(25),
+				"shared_cm": float64(1200),
+			},
+		},
+	}
+
+	records, err := provider.MapToInternal(data)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	assert.Equal(t, "PERSON", records[0].Type)
+	assert.Equal(t, "John", records[0].GivenName)
+	assert.Equal(t, "Doe", records[0].Surname)
+	assert.Equal(t, float64(25), records[0].Extra["shared_segments"])
+	assert.Equal(t, float64(1200), records[0].Extra["shared_cm"])
+}
+
+func TestProvider_MapToInternal_FTDNA(t *testing.T) {
+	provider := &ftDNAProvider{}
+
+	data := &ProviderData{
+		Records: []map[string]interface{}{
+			{
+				"type": "y_dna_match",
+				"match_name": "Y-DNA Match 1",
+				"genetic_distance": float64(1),
+				"haplogroup": "R-M269",
+			},
+		},
+	}
+
+	records, err := provider.MapToInternal(data)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	assert.Equal(t, "PERSON", records[0].Type)
+	assert.Equal(t, "y_dna_match", records[0].Extra["test_type"])
+	assert.Equal(t, "Y-DNA Match 1", records[0].Extra["dna_match_name"])
+	assert.Equal(t, float64(1), records[0].Extra["genetic_distance"])
+	assert.Equal(t, "R-M269", records[0].Extra["haplogroup"])
+}


### PR DESCRIPTION
What:
Implemented functional mock logic for DNA provider stubs in the `integration_service`. Instead of returning empty maps, the stubs for 23AndMe, AncestryDNA, and FamilyTreeDNA now yield hard-coded realistic data maps and securely parse them back into `InternalRecord` constructs without panicking due to absent keys.
Also, task T-4.1.2 was officially marked as completed in `docs/todo.md`.

Coverage:
Added test suite in `integration_service_test.go` fully targeting the specific implementations.

Result:
API consumers will now get simulated records as specified in the Phase 4 DNA integrations milestone, ensuring seamless e2e development continuity downstream.

---
*PR created automatically by Jules for task [7247948772275790108](https://jules.google.com/task/7247948772275790108) started by @chifamba*