### PR TITLE
feat: implement DNA provider API stubs

### DIFF
--- a/docs/openapi/genealogy-service.yaml
+++ b/docs/openapi/genealogy-service.yaml
@@ -708,6 +708,90 @@ paths:
         '404':
           description: Person not found
 
+  /persons/{id}/dna_tests:
+    post:
+      summary: Link a DNA test to a person
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: DNA test creation object
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  example: "Ancestry"
+                test_type:
+                  type: string
+                  example: "Autosomal"
+                kit_id:
+                  type: string
+                result_url:
+                  type: string
+                haplogroup_p:
+                  type: string
+                haplogroup_m:
+                  type: string
+                raw_data_s3_key:
+                  type: string
+              required:
+                - provider
+                - test_type
+      responses:
+        '200':
+          description: DNA test linked successfully
+        '400':
+          description: Invalid request body
+        '404':
+          description: Person not found
+
+    get:
+      summary: Get DNA tests for a person
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: List of DNA tests
+        '400':
+          description: Invalid person ID
+
+  /dna_tests/{id}/sync:
+    post:
+      summary: Sync DNA test data with provider
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: DNA test synchronized successfully
+        '400':
+          description: Invalid test ID
+        '404':
+          description: DNA test not found
+
   /relationships:
     post:
       summary: Create a new relationship between two persons

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Implemented in da173cd)
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/cmd/main.go
+++ b/services/genealogy_service/cmd/main.go
@@ -53,7 +53,8 @@ func main() {
 	// Initialize layers
 	repo := repository.NewNeo4jRepository(driver)
 	svc := service.NewGenealogyService(repo, eventBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	r := gin.New()
 	r.Use(gin.Recovery())

--- a/services/genealogy_service/internal/handlers/genealogy_handler.go
+++ b/services/genealogy_service/internal/handlers/genealogy_handler.go
@@ -12,11 +12,12 @@ import (
 )
 
 type GenealogyHandler struct {
-	svc service.Service
+	svc    service.Service
+	dnaSvc service.DNAService
 }
 
-func NewGenealogyHandler(svc service.Service) *GenealogyHandler {
-	return &GenealogyHandler{svc: svc}
+func NewGenealogyHandler(svc service.Service, dnaSvc service.DNAService) *GenealogyHandler {
+	return &GenealogyHandler{svc: svc, dnaSvc: dnaSvc}
 }
 
 func (h *GenealogyHandler) CreateTree(c *gin.Context) {
@@ -215,4 +216,77 @@ func (h *GenealogyHandler) ExportGEDCOM(c *gin.Context) {
 	c.Header("Content-Disposition", "attachment; filename=tree.ged")
 	c.Header("Content-Type", "application/octet-stream")
 	c.Data(http.StatusOK, "application/octet-stream", data)
+}
+
+func (h *GenealogyHandler) LinkDNATest(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person ID")
+		return
+	}
+
+	var req models.CreateDNATestRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	test := &models.DNATest{
+		Provider:     req.Provider,
+		TestType:     req.TestType,
+		KitID:        req.KitID,
+		ResultURL:    req.ResultURL,
+		HaplogroupP:  req.HaplogroupP,
+		HaplogroupM:  req.HaplogroupM,
+		RawDataS3Key: req.RawDataS3Key,
+	}
+
+	if err := h.dnaSvc.LinkDNATest(c.Request.Context(), personID, test); err != nil {
+		if err.Error() == "person not found" {
+			response.Error(c, http.StatusNotFound, "person not found")
+			return
+		}
+		response.Error(c, http.StatusInternalServerError, "failed to link DNA test")
+		return
+	}
+
+	response.Success(c, test)
+}
+
+func (h *GenealogyHandler) GetDNATests(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person ID")
+		return
+	}
+
+	tests, err := h.dnaSvc.GetDNATests(c.Request.Context(), personID)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "failed to get DNA tests")
+		return
+	}
+
+	response.Success(c, tests)
+}
+
+func (h *GenealogyHandler) SyncDNATest(c *gin.Context) {
+	testIDStr := c.Param("id")
+	testID, err := uuid.Parse(testIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid test ID")
+		return
+	}
+
+	if err := h.dnaSvc.SyncWithProvider(c.Request.Context(), testID); err != nil {
+		if err == service.ErrPersonNotFound {
+			response.Error(c, http.StatusNotFound, "DNA test not found")
+			return
+		}
+		response.Error(c, http.StatusInternalServerError, "failed to sync DNA test")
+		return
+	}
+
+	response.Success(c, map[string]string{"message": "DNA test synchronized successfully"})
 }

--- a/services/genealogy_service/internal/handlers/routes.go
+++ b/services/genealogy_service/internal/handlers/routes.go
@@ -29,6 +29,16 @@ func RegisterRoutes(r *gin.Engine, h *GenealogyHandler, jwtSecret string) {
 			persons.GET("/:id", h.GetPerson)
 			persons.PUT("/:id", h.UpdatePerson)
 			persons.DELETE("/:id", h.DeletePerson)
+
+			// DNA integration
+			persons.POST("/:id/dna_tests", h.LinkDNATest)
+			persons.GET("/:id/dna_tests", h.GetDNATests)
+		}
+
+		// DNA test syncing
+		dnaTests := api.Group("/dna_tests")
+		{
+			dnaTests.POST("/:id/sync", h.SyncDNATest)
 		}
 
 		// Relationship management

--- a/services/genealogy_service/internal/models/dto.go
+++ b/services/genealogy_service/internal/models/dto.go
@@ -28,3 +28,14 @@ type CreateRelationshipRequest struct {
 	Type      string                 `json:"type" binding:"required,oneof=PARENT_OF SPOUSE_OF SIBLING_OF"`
 	Metadata  map[string]interface{} `json:"metadata"`
 }
+
+// CreateDNATestRequest defines the payload for linking a DNA test to a person.
+type CreateDNATestRequest struct {
+	Provider     string `json:"provider" binding:"required"`
+	TestType     string `json:"test_type" binding:"required"`
+	KitID        string `json:"kit_id"`
+	ResultURL    string `json:"result_url"`
+	HaplogroupP  string `json:"haplogroup_p"`
+	HaplogroupM  string `json:"haplogroup_m"`
+	RawDataS3Key string `json:"raw_data_s3_key"`
+}

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -418,3 +418,159 @@ func (r *neo4jRepository) ListRelationshipsByTree(ctx context.Context, treeID st
 	}
 	return result.([]models.Relationship), nil
 }
+
+func (r *neo4jRepository) CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})
+			CREATE (d:DNATest {
+				id: $id,
+				provider: $provider,
+				test_type: $test_type,
+				kit_id: $kit_id,
+				result_url: $result_url,
+				haplogroup_p: $haplogroup_p,
+				haplogroup_m: $haplogroup_m,
+				raw_data_s3_key: $raw_data_s3_key,
+				created_at: $created_at
+			})
+			CREATE (p)-[:HAS_DNA_TEST]->(d)
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"person_id":       personID.String(),
+			"id":              test.ID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+			"created_at":      test.CreatedAt.Format(time.RFC3339),
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}
+
+func (r *neo4jRepository) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})-[:HAS_DNA_TEST]->(d:DNATest)
+			RETURN d
+		`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"person_id": personID.String()})
+		if err != nil {
+			return nil, err
+		}
+		var tests []models.DNATest
+		for res.Next(ctx) {
+			node := res.Record().Values[0].(neo4j.Node)
+			props := node.Props
+			id, _ := uuid.Parse(props["id"].(string))
+			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
+
+			tests = append(tests, models.DNATest{
+				ID:             id,
+				PersonID:       personID,
+				Provider:       props["provider"].(string),
+				TestType:       props["test_type"].(string),
+				KitID:          props["kit_id"].(string),
+				ResultURL:      props["result_url"].(string),
+				HaplogroupP:    props["haplogroup_p"].(string),
+				HaplogroupM:    props["haplogroup_m"].(string),
+				RawDataS3Key:   props["raw_data_s3_key"].(string),
+				CreatedAt:      createdAt,
+			})
+		}
+		return tests, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]models.DNATest), nil
+}
+
+func (r *neo4jRepository) GetDNATestByID(ctx context.Context, id uuid.UUID) (*models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person)-[:HAS_DNA_TEST]->(d:DNATest {id: $id})
+			RETURN p.id, d
+		`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"id": id.String()})
+		if err != nil {
+			return nil, err
+		}
+		if res.Next(ctx) {
+			personIDStr := res.Record().Values[0].(string)
+			personID, _ := uuid.Parse(personIDStr)
+			node := res.Record().Values[1].(neo4j.Node)
+			props := node.Props
+			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
+
+			return &models.DNATest{
+				ID:             id,
+				PersonID:       personID,
+				Provider:       props["provider"].(string),
+				TestType:       props["test_type"].(string),
+				KitID:          props["kit_id"].(string),
+				ResultURL:      props["result_url"].(string),
+				HaplogroupP:    props["haplogroup_p"].(string),
+				HaplogroupM:    props["haplogroup_m"].(string),
+				RawDataS3Key:   props["raw_data_s3_key"].(string),
+				CreatedAt:      createdAt,
+			}, nil
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return result.(*models.DNATest), nil
+}
+
+func (r *neo4jRepository) UpdateDNATest(ctx context.Context, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (d:DNATest {id: $id})
+			SET d.provider = $provider,
+				d.test_type = $test_type,
+				d.kit_id = $kit_id,
+				d.result_url = $result_url,
+				d.haplogroup_p = $haplogroup_p,
+				d.haplogroup_m = $haplogroup_m,
+				d.raw_data_s3_key = $raw_data_s3_key
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -25,4 +25,10 @@ type Repository interface {
 	DeleteRelationship(ctx context.Context, p1, p2 uuid.UUID, relType string) error
 	CheckCircularReference(ctx context.Context, p1, p2 uuid.UUID, relType string) (bool, error)
 	ListRelationshipsByTree(ctx context.Context, treeID string) ([]models.Relationship, error)
+
+	// DNATest operations
+	CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error
+	GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error)
+	GetDNATestByID(ctx context.Context, id uuid.UUID) (*models.DNATest, error)
+	UpdateDNATest(ctx context.Context, test *models.DNATest) error
 }

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -27,17 +27,43 @@ func (s *dnaService) LinkDNATest(ctx context.Context, personID uuid.UUID, test *
 	test.ID = uuid.New()
 	test.PersonID = personID
 	test.CreatedAt = time.Now()
-	// In a real implementation, this would save to Neo4j or Postgres
-	// For now, it's a stub that might just log
-	return nil
+
+	// Check if person exists before creating link
+	_, err := s.repo.GetPersonByID(ctx, personID)
+	if err != nil {
+		return err
+	}
+
+	return s.repo.CreateDNATest(ctx, personID, test)
 }
 
 func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
-	// Stub
-	return []models.DNATest{}, nil
+	return s.repo.GetDNATests(ctx, personID)
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
-	return nil
+	// 1. Get the existing DNA test
+	test, err := s.repo.GetDNATestByID(ctx, testID)
+	if err != nil {
+		return err
+	}
+	if test == nil {
+		return ErrPersonNotFound // In context of test, using simple error or custom
+	}
+
+	// 2. Functional mock data response (simulating Ancestry/23andMe)
+	// Since there are no public endpoints to call, we mock the result of a sync
+	if test.Provider == "Ancestry" {
+		test.HaplogroupP = "R-M269"
+		test.ResultURL = "https://ancestry.mock/results/" + test.KitID
+	} else if test.Provider == "23andMe" {
+		test.HaplogroupM = "H1a"
+		test.HaplogroupP = "E-M96"
+		test.ResultURL = "https://23andme.mock/reports/" + test.KitID
+	} else {
+		test.HaplogroupM = "L3"
+	}
+
+	// 3. Save the updated test
+	return s.repo.UpdateDNATest(ctx, test)
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -56,7 +56,8 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	repo := repository.NewNeo4jRepository(driver)
 	mockBus := &mockEventBus{} // or implement a simple mock
 	svc := service.NewGenealogyService(repo, mockBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()


### PR DESCRIPTION
Implemented the DNA provider API stubs (Task T-4.1.2) by establishing the endpoints and mock integration logic within the `genealogy_service`.

This includes updating the `neo4j_repository` to handle `DNATest` nodes, correctly wiring the `DNAService` in `main.go`, creating handling functions in `genealogy_handler.go`, mapping the routes, and documenting the endpoints in the OpenAPI spec. Tests successfully compile and run.

---
*PR created automatically by Jules for task [5291837915708840493](https://jules.google.com/task/5291837915708840493) started by @chifamba*