### PR TITLE
feat: implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed) (Implemented in latest)
 
 ### 4.2 AI Content Moderation
 

--- a/services/genealogy_service/cmd/main.go
+++ b/services/genealogy_service/cmd/main.go
@@ -53,7 +53,8 @@ func main() {
 	// Initialize layers
 	repo := repository.NewNeo4jRepository(driver)
 	svc := service.NewGenealogyService(repo, eventBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	r := gin.New()
 	r.Use(gin.Recovery())

--- a/services/genealogy_service/internal/handlers/genealogy_handler.go
+++ b/services/genealogy_service/internal/handlers/genealogy_handler.go
@@ -12,11 +12,12 @@ import (
 )
 
 type GenealogyHandler struct {
-	svc service.Service
+	svc    service.Service
+	dnaSvc service.DNAService
 }
 
-func NewGenealogyHandler(svc service.Service) *GenealogyHandler {
-	return &GenealogyHandler{svc: svc}
+func NewGenealogyHandler(svc service.Service, dnaSvc service.DNAService) *GenealogyHandler {
+	return &GenealogyHandler{svc: svc, dnaSvc: dnaSvc}
 }
 
 func (h *GenealogyHandler) CreateTree(c *gin.Context) {
@@ -215,4 +216,44 @@ func (h *GenealogyHandler) ExportGEDCOM(c *gin.Context) {
 	c.Header("Content-Disposition", "attachment; filename=tree.ged")
 	c.Header("Content-Type", "application/octet-stream")
 	c.Data(http.StatusOK, "application/octet-stream", data)
+}
+
+// DNA Handlers
+func (h *GenealogyHandler) LinkDNATest(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person ID format")
+		return
+	}
+
+	var test models.DNATest
+	if err := c.ShouldBindJSON(&test); err != nil {
+		response.Error(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.dnaSvc.LinkDNATest(c.Request.Context(), personID, &test); err != nil {
+		response.Error(c, http.StatusInternalServerError, "failed to link DNA test")
+		return
+	}
+
+	c.JSON(http.StatusCreated, test)
+}
+
+func (h *GenealogyHandler) GetDNATests(c *gin.Context) {
+	personIDStr := c.Param("id")
+	personID, err := uuid.Parse(personIDStr)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, "invalid person ID format")
+		return
+	}
+
+	tests, err := h.dnaSvc.GetDNATests(c.Request.Context(), personID)
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "failed to fetch DNA tests")
+		return
+	}
+
+	c.JSON(http.StatusOK, tests)
 }

--- a/services/genealogy_service/internal/handlers/routes.go
+++ b/services/genealogy_service/internal/handlers/routes.go
@@ -29,6 +29,10 @@ func RegisterRoutes(r *gin.Engine, h *GenealogyHandler, jwtSecret string) {
 			persons.GET("/:id", h.GetPerson)
 			persons.PUT("/:id", h.UpdatePerson)
 			persons.DELETE("/:id", h.DeletePerson)
+
+            // DNA Tests
+            persons.POST("/:id/dna", h.LinkDNATest)
+            persons.GET("/:id/dna", h.GetDNATests)
 		}
 
 		// Relationship management

--- a/services/genealogy_service/internal/repository/neo4j_repository.go
+++ b/services/genealogy_service/internal/repository/neo4j_repository.go
@@ -102,12 +102,13 @@ func (r *neo4jRepository) ListTreesByOwner(ctx context.Context, ownerID uuid.UUI
 		for res.Next(ctx) {
 			node := res.Record().Values[0].(neo4j.Node)
 			props := node.Props
+			oID, _ := uuid.Parse(props["owner_id"].(string))
 			createdAt, _ := time.Parse(time.RFC3339, props["created_at"].(string))
 			updatedAt, _ := time.Parse(time.RFC3339, props["updated_at"].(string))
 
 			trees = append(trees, models.FamilyTree{
 				ID:           props["id"].(string),
-				OwnerID:      ownerID,
+				OwnerID:      oID,
 				Name:         props["name"].(string),
 				Description:  props["description"].(string),
 				PrivacyLevel: props["privacy_level"].(string),
@@ -417,4 +418,142 @@ func (r *neo4jRepository) ListRelationshipsByTree(ctx context.Context, treeID st
 		return nil, err
 	}
 	return result.([]models.Relationship), nil
+}
+
+func (r *neo4jRepository) CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (p:Person {id: $person_id})
+			CREATE (d:DNATest {
+				id: $id,
+				person_id: $person_id,
+				provider: $provider,
+				test_type: $test_type,
+				kit_id: $kit_id,
+				result_url: $result_url,
+				haplogroup_p: $haplogroup_p,
+				haplogroup_m: $haplogroup_m,
+				raw_data_s3_key: $raw_data_s3_key,
+				created_at: $created_at
+			})
+			CREATE (p)-[:HAS_DNA_TEST]->(d)
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"person_id":       personID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+			"created_at":      test.CreatedAt.Format(time.RFC3339),
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
+}
+
+func (r *neo4jRepository) GetDNATestsByPerson(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer session.Close(ctx)
+
+	result, err := session.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `MATCH (p:Person {id: $person_id})-[:HAS_DNA_TEST]->(d:DNATest) RETURN d`
+		res, err := tx.Run(ctx, query, map[string]interface{}{"person_id": personID.String()})
+		if err != nil {
+			return nil, err
+		}
+		var tests []models.DNATest
+		for res.Next(ctx) {
+			node := res.Record().Values[0].(neo4j.Node)
+			props := node.Props
+
+			idStr, _ := props["id"].(string)
+			id, _ := uuid.Parse(idStr)
+
+			pIDStr, _ := props["person_id"].(string)
+			pID, _ := uuid.Parse(pIDStr)
+
+			createdAtStr, _ := props["created_at"].(string)
+			createdAt, _ := time.Parse(time.RFC3339, createdAtStr)
+
+			provider, ok := props["provider"].(string)
+			if !ok { provider = "" }
+
+			testType, ok := props["test_type"].(string)
+			if !ok { testType = "" }
+
+			kitID, ok := props["kit_id"].(string)
+			if !ok { kitID = "" }
+
+			resultURL, ok := props["result_url"].(string)
+			if !ok { resultURL = "" }
+
+			haplogroupP, ok := props["haplogroup_p"].(string)
+			if !ok { haplogroupP = "" }
+
+			haplogroupM, ok := props["haplogroup_m"].(string)
+			if !ok { haplogroupM = "" }
+
+			rawDataS3Key, ok := props["raw_data_s3_key"].(string)
+			if !ok { rawDataS3Key = "" }
+
+			tests = append(tests, models.DNATest{
+				ID:             id,
+				PersonID:       pID,
+				Provider:       provider,
+				TestType:       testType,
+				KitID:          kitID,
+				ResultURL:      resultURL,
+				HaplogroupP:    haplogroupP,
+				HaplogroupM:    haplogroupM,
+				RawDataS3Key:   rawDataS3Key,
+				CreatedAt:      createdAt,
+			})
+		}
+		return tests, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]models.DNATest), nil
+}
+
+func (r *neo4jRepository) UpdateDNATest(ctx context.Context, test *models.DNATest) error {
+	session := r.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer session.Close(ctx)
+
+	_, err := session.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		query := `
+			MATCH (d:DNATest {id: $id})
+			SET d.provider = $provider,
+				d.test_type = $test_type,
+				d.kit_id = $kit_id,
+				d.result_url = $result_url,
+				d.haplogroup_p = $haplogroup_p,
+				d.haplogroup_m = $haplogroup_m,
+				d.raw_data_s3_key = $raw_data_s3_key
+			RETURN d
+		`
+		params := map[string]interface{}{
+			"id":              test.ID.String(),
+			"provider":        test.Provider,
+			"test_type":       test.TestType,
+			"kit_id":          test.KitID,
+			"result_url":      test.ResultURL,
+			"haplogroup_p":    test.HaplogroupP,
+			"haplogroup_m":    test.HaplogroupM,
+			"raw_data_s3_key": test.RawDataS3Key,
+		}
+		_, err := tx.Run(ctx, query, params)
+		return nil, err
+	})
+	return err
 }

--- a/services/genealogy_service/internal/repository/repository.go
+++ b/services/genealogy_service/internal/repository/repository.go
@@ -25,4 +25,9 @@ type Repository interface {
 	DeleteRelationship(ctx context.Context, p1, p2 uuid.UUID, relType string) error
 	CheckCircularReference(ctx context.Context, p1, p2 uuid.UUID, relType string) (bool, error)
 	ListRelationshipsByTree(ctx context.Context, treeID string) ([]models.Relationship, error)
+
+	// DNA operations
+	CreateDNATest(ctx context.Context, personID uuid.UUID, test *models.DNATest) error
+	GetDNATestsByPerson(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error)
+	UpdateDNATest(ctx context.Context, test *models.DNATest) error
 }

--- a/services/genealogy_service/internal/service/dna_service.go
+++ b/services/genealogy_service/internal/service/dna_service.go
@@ -27,17 +27,17 @@ func (s *dnaService) LinkDNATest(ctx context.Context, personID uuid.UUID, test *
 	test.ID = uuid.New()
 	test.PersonID = personID
 	test.CreatedAt = time.Now()
-	// In a real implementation, this would save to Neo4j or Postgres
-	// For now, it's a stub that might just log
-	return nil
+
+	// Delegate to the repository implementation
+	return s.repo.CreateDNATest(ctx, personID, test)
 }
 
 func (s *dnaService) GetDNATests(ctx context.Context, personID uuid.UUID) ([]models.DNATest, error) {
-	// Stub
-	return []models.DNATest{}, nil
+	// Delegate to the repository implementation
+	return s.repo.GetDNATestsByPerson(ctx, personID)
 }
 
 func (s *dnaService) SyncWithProvider(ctx context.Context, testID uuid.UUID) error {
-	// Stub for syncing with Ancestry, 23andMe, etc.
+	// Stub for syncing with Ancestry, 23andMe, etc. Since we only need to provide stubs and mock endpoints as there are no actual public APIs
 	return nil
 }

--- a/services/genealogy_service/tests/integration/integration_test.go
+++ b/services/genealogy_service/tests/integration/integration_test.go
@@ -56,7 +56,8 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	repo := repository.NewNeo4jRepository(driver)
 	mockBus := &mockEventBus{} // or implement a simple mock
 	svc := service.NewGenealogyService(repo, mockBus)
-	handler := handlers.NewGenealogyHandler(svc)
+	dnaSvc := service.NewDNAService(repo)
+	handler := handlers.NewGenealogyHandler(svc, dnaSvc)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -65,7 +66,7 @@ func TestGenealogyServiceIntegration(t *testing.T) {
 	// Helper to generate token
 	ownerID := uuid.New()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": ownerID.String(),
+		"sub": ownerID.String(),
 		"roles":   []string{"user"},
 		"exp":     time.Now().Add(time.Hour).Unix(),
 	})


### PR DESCRIPTION
Added DNA integration and stub functionalities.

What:
- Added Neo4j repo implementations for DNA operations (`CreateDNATest`, `GetDNATestsByPerson`, `UpdateDNATest`).
- Correctly implemented API handlers `LinkDNATest` and `GetDNATests` within the `genealogy_handler.go`.
- Added route bindings for DNA tests in `routes.go`.
- Verified and fixed integration test mappings (`sub` instead of `user_id` claim in JWT tests).
- Checked off task `T-4.1.2` in `todo.md`.

Coverage: Tested API endpoints locally and passed integration suites.
Result: Functional stubs that correctly insert/read from the DB.

---
*PR created automatically by Jules for task [8918447003080627398](https://jules.google.com/task/8918447003080627398) started by @chifamba*