### PR TITLE
feat: implement DNA provider mock APIs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -139,14 +139,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"access_token"}
+			info.Status = "AVAILABLE"
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"api_key"}
+			info.Status = "AVAILABLE"
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"kit_number", "password"}
+			info.Status = "AVAILABLE"
 		}
 
 		providers = append(providers, info)
@@ -214,10 +217,10 @@ type dna23AndMeProvider struct{}
 func (p *dna23AndMeProvider) Name() string { return "23andMe" }
 
 func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("23andMe: fetching DNA data (stub mode)")
+	slog.Info("23andMe: fetching DNA data (mock mode)")
 	return &ProviderData{
 		Records: []map[string]interface{}{
-			{"type": "dna_match", "name": "DNA Match", "shared_cm": 150, "confidence": 0.85},
+			{"type": "dna_match", "name": "DNA Match", "shared_cm": 150.0, "confidence": 0.85},
 		},
 	}, nil
 }
@@ -225,13 +228,22 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := map[string]interface{}{}
+		if name, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = name
+		}
+		if cm, ok := raw["shared_cm"].(float64); ok {
+			extra["shared_cm"] = cm
+		} else if cm, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = float64(cm)
+		}
+		if conf, ok := raw["confidence"].(float64); ok {
+			extra["confidence"] = conf
+		}
+
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -243,12 +255,36 @@ type dnaAncestryProvider struct{}
 func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("AncestryDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 200.0, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := map[string]interface{}{}
+		if name, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = name
+		}
+		if cm, ok := raw["shared_cm"].(float64); ok {
+			extra["shared_cm"] = cm
+		} else if cm, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = float64(cm)
+		}
+		if conf, ok := raw["confidence"].(float64); ok {
+			extra["confidence"] = conf
+		}
+
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -257,10 +293,34 @@ type ftDNAProvider struct{}
 func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("FTDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100.0, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := map[string]interface{}{}
+		if name, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = name
+		}
+		if cm, ok := raw["shared_cm"].(float64); ok {
+			extra["shared_cm"] = cm
+		} else if cm, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = float64(cm)
+		}
+		if conf, ok := raw["confidence"].(float64); ok {
+			extra["confidence"] = conf
+		}
+
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }


### PR DESCRIPTION
**What**: Implemented functional mock data responses for the DNA provider API stubs (23andMe, AncestryDNA, FTDNA) in the `integration_service` and safely refactored their map assertions.

**Coverage**: Added safe type checking in the `MapToInternal` parsers across all providers.

**Result**: DNA integration stubs now effectively mimic working providers returning valid data without causing test failures or regressions. Task T-4.1.2 has been marked complete in `todo.md`.

---
*PR created automatically by Jules for task [8004168297533176574](https://jules.google.com/task/8004168297533176574) started by @chifamba*