### PR TITLE
feat: implement DNA provider API stubs in integration_service

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Implemented)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -184,12 +187,17 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		rec := InternalRecord{Type: "PERSON"}
+		if v, ok := raw["given_name"].(string); ok {
+			rec.GivenName = v
+		}
+		if v, ok := raw["surname"].(string); ok {
+			rec.Surname = v
+		}
+		if v, ok := raw["birth_date"].(string); ok {
+			rec.BirthDate = v
+		}
+		records = append(records, rec)
 	}
 	return records, nil
 }
@@ -225,13 +233,19 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if v, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = v
+		}
+		if v, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = v
+		}
+		if v, ok := raw["confidence"]; ok {
+			extra["confidence"] = v
+		}
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +258,32 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if v, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = v
+		}
+		if v, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = v
+		}
+		if v, ok := raw["confidence"]; ok {
+			extra["confidence"] = v
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +293,30 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 50, "confidence": 0.60},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if v, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = v
+		}
+		if v, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = v
+		}
+		if v, ok := raw["confidence"]; ok {
+			extra["confidence"] = v
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationService_ListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	assert.NotEmpty(t, providers)
+
+	dnaProviderStatusCheck := map[string]bool{
+		"23andMe":     false,
+		"AncestryDNA": false,
+		"FTDNA":       false,
+	}
+
+	for _, p := range providers {
+		if _, ok := dnaProviderStatusCheck[p.Name]; ok {
+			assert.Equal(t, "AVAILABLE", p.Status, "Provider %s should have status AVAILABLE", p.Name)
+			dnaProviderStatusCheck[p.Name] = true
+		}
+	}
+
+	for name, found := range dnaProviderStatusCheck {
+		assert.True(t, found, "DNA provider %s not found in ListProviders output", name)
+	}
+}
+
+func TestIntegrationService_SyncExternalData_DNA(t *testing.T) {
+	svc := NewIntegrationService()
+
+	testCases := []struct {
+		providerName string
+		expectedName string
+	}{
+		{"23andMe", "DNA Match"},
+		{"AncestryDNA", "Ancestry Match"},
+		{"FTDNA", "FTDNA Match"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.providerName, func(t *testing.T) {
+			ctx := context.Background()
+			config := map[string]string{"dummy_token": "123"}
+
+			result, err := svc.SyncExternalData(ctx, tc.providerName, config)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.providerName, result.Provider)
+			assert.Equal(t, 1, result.RecordsFetched)
+			assert.Equal(t, 1, result.RecordsMapped)
+			assert.True(t, result.Duration >= 0)
+
+			// Get provider directly to check MapToInternal
+			svcImpl, ok := svc.(*integrationService)
+			require.True(t, ok)
+			provider := svcImpl.providers[strings.ToLower(tc.providerName)]
+
+			data, err := provider.FetchData(ctx, config)
+			require.NoError(t, err)
+
+			records, err := provider.MapToInternal(data)
+			require.NoError(t, err)
+			require.Len(t, records, 1)
+
+			rec := records[0]
+			assert.Equal(t, "PERSON", rec.Type)
+
+			extraName, ok := rec.Extra["dna_match_name"].(string)
+			assert.True(t, ok)
+			assert.Equal(t, tc.expectedName, extraName)
+		})
+	}
+}


### PR DESCRIPTION
This PR fulfills the requirement to implement the DNA provider API stubs (Task T-4.1.2).

### What
- Fleshed out the `FetchData` and `MapToInternal` functions for the `dnaAncestryProvider` and `ftDNAProvider`.
- Enhanced `MapToInternal` in `familySearchProvider` and `dna23AndMeProvider` to safely assert and map data without causing `nil` literals or potential application panics.
- Updated the status strings to "AVAILABLE" in `ListProviders`.
- Added unit tests.

### Coverage
- `services/integration_service/internal/service/integration_service.go` and its respective test suite.

### Result
- The Integration Service now properly simulates mock responses and maps incoming data without errors, allowing upstream services to mock DNA integrations safely.
- All backend tests pass successfully.

---
*PR created automatically by Jules for task [11134972787816412688](https://jules.google.com/task/11134972787816412688) started by @chifamba*