### PR TITLE
✨ [feat] implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Implemented in this branch)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -136,14 +136,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 			info.Category = "GENEALOGY"
 			info.RequiredConfig = []string{"api_key", "tree_id"}
 		case "23andMe":
+			info.Status = "AVAILABLE"
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
+			info.Status = "AVAILABLE"
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
+			info.Status = "AVAILABLE"
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"kit_number", "password"}
@@ -184,12 +187,17 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		rec := InternalRecord{Type: "PERSON"}
+		if v, ok := raw["given_name"].(string); ok {
+			rec.GivenName = v
+		}
+		if v, ok := raw["surname"].(string); ok {
+			rec.Surname = v
+		}
+		if v, ok := raw["birth_date"].(string); ok {
+			rec.BirthDate = v
+		}
+		records = append(records, rec)
 	}
 	return records, nil
 }
@@ -225,13 +233,19 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if v, ok := raw["name"]; ok && v != nil {
+			extra["dna_match_name"] = v
+		}
+		if v, ok := raw["shared_cm"]; ok && v != nil {
+			extra["shared_cm"] = v
+		}
+		if v, ok := raw["confidence"]; ok && v != nil {
+			extra["confidence"] = v
+		}
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +258,32 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 250, "confidence": 0.95},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if v, ok := raw["name"]; ok && v != nil {
+			extra["dna_match_name"] = v
+		}
+		if v, ok := raw["shared_cm"]; ok && v != nil {
+			extra["shared_cm"] = v
+		}
+		if v, ok := raw["confidence"]; ok && v != nil {
+			extra["confidence"] = v
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +293,30 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 350, "confidence": 0.99},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if v, ok := raw["name"]; ok && v != nil {
+			extra["dna_match_name"] = v
+		}
+		if v, ok := raw["shared_cm"]; ok && v != nil {
+			extra["shared_cm"] = v
+		}
+		if v, ok := raw["confidence"]; ok && v != nil {
+			extra["confidence"] = v
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIntegrationService(t *testing.T) {
+	svc := NewIntegrationService()
+	require.NotNil(t, svc)
+
+	// Since we know providers map is private, we can verify providers via ListProviders
+	providers := svc.ListProviders(context.Background())
+	assert.Len(t, providers, 5) // FamilySearch, Ancestry, 23andMe, AncestryDNA, FTDNA
+}
+
+func TestListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	// Convert list to map for easier assertions
+	providerMap := make(map[string]ProviderInfo)
+	for _, p := range providers {
+		providerMap[p.Name] = p
+	}
+
+	dnaProviders := []string{"23andMe", "AncestryDNA", "FTDNA"}
+	for _, name := range dnaProviders {
+		p, ok := providerMap[name]
+		require.True(t, ok, "Expected provider %s to exist", name)
+		assert.Equal(t, "AVAILABLE", p.Status, "Expected %s to have AVAILABLE status", name)
+		assert.Equal(t, "DNA", p.Category, "Expected %s to be in DNA category", name)
+	}
+
+	genealogyProviders := []string{"FamilySearch", "Ancestry"}
+	for _, name := range genealogyProviders {
+		p, ok := providerMap[name]
+		require.True(t, ok, "Expected provider %s to exist", name)
+		assert.Equal(t, "STUB", p.Status, "Expected %s to have STUB status", name)
+		assert.Equal(t, "GENEALOGY", p.Category, "Expected %s to be in GENEALOGY category", name)
+	}
+}
+
+func TestSyncExternalData(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+
+	tests := []struct {
+		providerName  string
+		expectedRecs  int
+		expectError   bool
+	}{
+		{providerName: "23andMe", expectedRecs: 1, expectError: false},
+		{providerName: "AncestryDNA", expectedRecs: 1, expectError: false},
+		{providerName: "FTDNA", expectedRecs: 1, expectError: false},
+		{providerName: "FamilySearch", expectedRecs: 1, expectError: false},
+		{providerName: "Ancestry", expectedRecs: 0, expectError: false},
+		{providerName: "Unknown", expectedRecs: 0, expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.providerName, func(t *testing.T) {
+			result, err := svc.SyncExternalData(ctx, tt.providerName, map[string]string{})
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, tt.providerName, result.Provider)
+				assert.Equal(t, tt.expectedRecs, result.RecordsFetched)
+				assert.Equal(t, tt.expectedRecs, result.RecordsMapped)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented DNA provider API stubs as requested in todo.md (Task T-4.1.2).

Changes:
- Set status of DNA providers (23andMe, AncestryDNA, FTDNA) to AVAILABLE.
- Implemented functional mock data extraction for AncestryDNA and FTDNA.
- Refactored `MapToInternal` for 23andMe and FamilySearch to correctly check map keys using type assertions, preventing nil values stringification (`"<nil>"`).
- Added `integration_service_test.go` to test functionality.
- Updated `docs/todo.md` checking off task T-4.1.2.
- Cleaned and verified service execution via `go test`.

---
*PR created automatically by Jules for task [3301561726555345018](https://jules.google.com/task/3301561726555345018) started by @chifamba*