### PR TITLE
feat(integration_service): Implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Implemented)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -184,12 +187,17 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		rec := InternalRecord{Type: "PERSON"}
+		if val, ok := raw["given_name"].(string); ok {
+			rec.GivenName = val
+		}
+		if val, ok := raw["surname"].(string); ok {
+			rec.Surname = val
+		}
+		if val, ok := raw["birth_date"].(string); ok {
+			rec.BirthDate = val
+		}
+		records = append(records, rec)
 	}
 	return records, nil
 }
@@ -214,10 +222,10 @@ type dna23AndMeProvider struct{}
 func (p *dna23AndMeProvider) Name() string { return "23andMe" }
 
 func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("23andMe: fetching DNA data (stub mode)")
+	slog.Info("23andMe: fetching DNA data (mock mode)")
 	return &ProviderData{
 		Records: []map[string]interface{}{
-			{"type": "dna_match", "name": "DNA Match", "shared_cm": 150, "confidence": 0.85},
+			{"type": "dna_match", "name": "DNA Match 23", "shared_cm": float64(150), "confidence": float64(0.85)},
 		},
 	}, nil
 }
@@ -225,14 +233,20 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
-		})
+		rec := InternalRecord{
+			Type:  "PERSON",
+			Extra: make(map[string]interface{}),
+		}
+		if val, ok := raw["name"]; ok {
+			rec.Extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			rec.Extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			rec.Extra["confidence"] = val
+		}
+		records = append(records, rec)
 	}
 	return records, nil
 }
@@ -243,12 +257,33 @@ type dnaAncestryProvider struct{}
 func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("AncestryDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "DNA Match ADNA", "shared_cm": float64(200), "confidence": float64(0.95)},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		rec := InternalRecord{
+			Type:  "PERSON",
+			Extra: make(map[string]interface{}),
+		}
+		if val, ok := raw["name"]; ok {
+			rec.Extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			rec.Extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			rec.Extra["confidence"] = val
+		}
+		records = append(records, rec)
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -257,10 +292,31 @@ type ftDNAProvider struct{}
 func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("FTDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "DNA Match FTDNA", "shared_cm": float64(100), "confidence": float64(0.75)},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		rec := InternalRecord{
+			Type:  "PERSON",
+			Extra: make(map[string]interface{}),
+		}
+		if val, ok := raw["name"]; ok {
+			rec.Extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			rec.Extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			rec.Extra["confidence"] = val
+		}
+		records = append(records, rec)
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	if len(providers) != 5 {
+		t.Errorf("Expected 5 providers, got %d", len(providers))
+	}
+
+	for _, p := range providers {
+		switch p.Name {
+		case "23andMe", "AncestryDNA", "FTDNA":
+			if p.Status != "AVAILABLE" {
+				t.Errorf("Expected DNA provider %s to be AVAILABLE, got %s", p.Name, p.Status)
+			}
+		case "FamilySearch", "Ancestry":
+			if p.Status != "STUB" {
+				t.Errorf("Expected genealogy provider %s to be STUB, got %s", p.Name, p.Status)
+			}
+		}
+	}
+}
+
+func TestSyncExternalData_DNAMockData(t *testing.T) {
+	svc := NewIntegrationService()
+
+	tests := []struct {
+		providerName string
+		expectedName string
+	}{
+		{"23andMe", "DNA Match 23"},
+		{"AncestryDNA", "DNA Match ADNA"},
+		{"FTDNA", "DNA Match FTDNA"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.providerName, func(t *testing.T) {
+			res, err := svc.SyncExternalData(context.Background(), tt.providerName, nil)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+
+			if res.RecordsFetched != 1 {
+				t.Errorf("Expected 1 record fetched for %s, got %d", tt.providerName, res.RecordsFetched)
+			}
+			if res.RecordsMapped != 1 {
+				t.Errorf("Expected 1 record mapped for %s, got %d", tt.providerName, res.RecordsMapped)
+			}
+		})
+	}
+}


### PR DESCRIPTION
What:
- Refactored DNA providers (`23andMe`, `AncestryDNA`, `FTDNA`) to return mock DNA match records.
- Safely mapped the raw map payload to `InternalRecord` using safe type assertions instead of `fmt.Sprint`.
- Marked DNA providers as `AVAILABLE` instead of `STUB`.
- Added unit tests for `IntegrationService`'s `ListProviders` and `SyncExternalData`.

Coverage:
- Tests the provider configurations, making sure DNA providers show up as `AVAILABLE`.
- Tests the `SyncExternalData` against mock providers making sure they parse correctly.

Result:
- We can now simulate integrations with external DNA providers via `integration_service` as specified in the Phase 4 requirements.
- Checked off task `T-4.1.2` in `docs/todo.md`.

---
*PR created automatically by Jules for task [16359898587397575550](https://jules.google.com/task/16359898587397575550) started by @chifamba*