### PR TITLE
feat: implement functional DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -184,12 +187,17 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		record := InternalRecord{Type: "PERSON"}
+		if givenName, ok := raw["given_name"].(string); ok {
+			record.GivenName = givenName
+		}
+		if surname, ok := raw["surname"].(string); ok {
+			record.Surname = surname
+		}
+		if birthDate, ok := raw["birth_date"].(string); ok {
+			record.BirthDate = birthDate
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }
@@ -225,13 +233,19 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok && name != nil {
+			extra["dna_match_name"] = name
+		}
+		if sharedCM, ok := raw["shared_cm"]; ok && sharedCM != nil {
+			extra["shared_cm"] = sharedCM
+		}
+		if confidence, ok := raw["confidence"]; ok && confidence != nil {
+			extra["confidence"] = confidence
+		}
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +258,32 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "AncestryDNA Match", "shared_cm": 200, "confidence": 0.95},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok && name != nil {
+			extra["dna_match_name"] = name
+		}
+		if sharedCM, ok := raw["shared_cm"]; ok && sharedCM != nil {
+			extra["shared_cm"] = sharedCM
+		}
+		if confidence, ok := raw["confidence"]; ok && confidence != nil {
+			extra["confidence"] = confidence
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +293,30 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 300, "confidence": 0.99},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok && name != nil {
+			extra["dna_match_name"] = name
+		}
+		if sharedCM, ok := raw["shared_cm"]; ok && sharedCM != nil {
+			extra["shared_cm"] = sharedCM
+		}
+		if confidence, ok := raw["confidence"]; ok && confidence != nil {
+			extra["confidence"] = confidence
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }


### PR DESCRIPTION
- Added proper unmarshalling of nested interfaces to solve task `T-4.1.2`.
- Avoided hallucinating external HTTP calls, relying instead on structured mock datasets mapped into our application's `InternalRecord` format as per memory requirements.
- Reverted unintentional go.mod changes in other services generated during `go mod tidy` in the test loops.

---
*PR created automatically by Jules for task [8179155935497901591](https://jules.google.com/task/8179155935497901591) started by @chifamba*