### PR TITLE
feat(integration): implement dna provider stubs with mock data

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -214,7 +217,7 @@ type dna23AndMeProvider struct{}
 func (p *dna23AndMeProvider) Name() string { return "23andMe" }
 
 func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("23andMe: fetching DNA data (stub mode)")
+	slog.Info("23andMe: fetching DNA data (mock mode)")
 	return &ProviderData{
 		Records: []map[string]interface{}{
 			{"type": "dna_match", "name": "DNA Match", "shared_cm": 150, "confidence": 0.85},
@@ -225,13 +228,19 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := map[string]interface{}{}
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -243,12 +252,33 @@ type dnaAncestryProvider struct{}
 func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("AncestryDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := map[string]interface{}{}
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -257,10 +287,31 @@ type ftDNAProvider struct{}
 func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("FTDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 120, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := map[string]interface{}{}
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIntegrationService_DNAProviders(t *testing.T) {
+	svc := NewIntegrationService()
+
+	// 1. Verify that ListProviders marks the DNA providers as AVAILABLE
+	providers := svc.ListProviders(context.Background())
+	providerStatuses := make(map[string]string)
+	for _, p := range providers {
+		providerStatuses[p.Name] = p.Status
+	}
+
+	dnaProviders := []string{"23andMe", "AncestryDNA", "FTDNA"}
+	for _, name := range dnaProviders {
+		if status := providerStatuses[name]; status != "AVAILABLE" {
+			t.Errorf("Expected status for %s to be AVAILABLE, got %s", name, status)
+		}
+	}
+
+	// 2. Test SyncExternalData for each DNA provider to verify RecordsFetched > 0
+	for _, name := range dnaProviders {
+		res, err := svc.SyncExternalData(context.Background(), name, map[string]string{})
+		if err != nil {
+			t.Fatalf("SyncExternalData failed for %s: %v", name, err)
+		}
+
+		if res.RecordsFetched == 0 {
+			t.Errorf("Expected RecordsFetched > 0 for %s", name)
+		}
+
+		if res.RecordsMapped == 0 {
+			t.Errorf("Expected RecordsMapped > 0 for %s", name)
+		}
+
+		if res.RecordsFetched != res.RecordsMapped {
+			t.Errorf("Expected RecordsFetched (%d) to equal RecordsMapped (%d) for %s", res.RecordsFetched, res.RecordsMapped, name)
+		}
+	}
+}


### PR DESCRIPTION
Implements the DNA provider stubs (T-4.1.2) using functional mock data to allow local testing and development of the integration service without real external API calls.

---
*PR created automatically by Jules for task [6914226896888311811](https://jules.google.com/task/6914226896888311811) started by @chifamba*