### PR TITLE
feat(integration): implement DNA provider API stubs with mock data

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed) (Implemented in da173cd)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -184,12 +187,17 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		record := InternalRecord{Type: "PERSON"}
+		if val, ok := raw["given_name"].(string); ok {
+			record.GivenName = val
+		}
+		if val, ok := raw["surname"].(string); ok {
+			record.Surname = val
+		}
+		if val, ok := raw["birth_date"].(string); ok {
+			record.BirthDate = val
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }
@@ -225,13 +233,19 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +258,32 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match", "shared_cm": 200, "confidence": 0.9},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +293,30 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 300, "confidence": 0.95},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIntegrationService_ListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	if len(providers) == 0 {
+		t.Fatalf("expected providers, got 0")
+	}
+
+	dnaProviders := map[string]bool{
+		"23andMe":     true,
+		"AncestryDNA": true,
+		"FTDNA":       true,
+	}
+
+	for _, p := range providers {
+		if dnaProviders[p.Name] {
+			if p.Status != "AVAILABLE" {
+				t.Errorf("expected DNA provider %s to be AVAILABLE, got %s", p.Name, p.Status)
+			}
+		}
+	}
+}
+
+func TestIntegrationService_SyncExternalData_AncestryDNA(t *testing.T) {
+	svc := NewIntegrationService()
+	providerName := "ancestrydna"
+
+	result, err := svc.SyncExternalData(context.Background(), providerName, nil)
+	if err != nil {
+		t.Fatalf("expected no error for AncestryDNA sync, got %v", err)
+	}
+
+	if result.Provider != providerName {
+		t.Errorf("expected provider %s, got %s", providerName, result.Provider)
+	}
+
+	if result.RecordsFetched != 1 {
+		t.Errorf("expected 1 record fetched for AncestryDNA, got %d", result.RecordsFetched)
+	}
+
+	if result.RecordsMapped != 1 {
+		t.Errorf("expected 1 record mapped for AncestryDNA, got %d", result.RecordsMapped)
+	}
+}
+
+func TestIntegrationService_SyncExternalData_FTDNA(t *testing.T) {
+	svc := NewIntegrationService()
+	providerName := "ftdna"
+
+	result, err := svc.SyncExternalData(context.Background(), providerName, nil)
+	if err != nil {
+		t.Fatalf("expected no error for FTDNA sync, got %v", err)
+	}
+
+	if result.Provider != providerName {
+		t.Errorf("expected provider %s, got %s", providerName, result.Provider)
+	}
+
+	if result.RecordsFetched != 1 {
+		t.Errorf("expected 1 record fetched for FTDNA, got %d", result.RecordsFetched)
+	}
+
+	if result.RecordsMapped != 1 {
+		t.Errorf("expected 1 record mapped for FTDNA, got %d", result.RecordsMapped)
+	}
+}


### PR DESCRIPTION
This PR implements the DNA provider API stubs (T-4.1.2) for the `integration_service`. 

It replaces empty returns with functional mock data in `FetchData` and `MapToInternal` for the AncestryDNA and FTDNA provider integrations. It also improves safety in `MapToInternal` for `familySearchProvider` and `dna23AndMeProvider` by replacing direct assignments and `fmt.Sprint()` with explicit existence checks and type assertions to prevent evaluating to literal `"<nil>"` strings if keys are missing from the raw payload maps. 

The DNA providers (23andMe, AncestryDNA, and FTDNA) are now explicitly marked as `"AVAILABLE"` in `ListProviders`. 

Comprehensive test coverage (`integration_service_test.go`) has been added to ensure the correct endpoints are available and the stubs sync the external mock data properly. The overall codebase tests run via `go test ./... -short` and verified no regressions.

---
*PR created automatically by Jules for task [13057265186000944920](https://jules.google.com/task/13057265186000944920) started by @chifamba*