### PR TITLE
feat(integration): implement functional mock data for DNA provider stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -225,13 +228,19 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -243,12 +252,33 @@ type dnaAncestryProvider struct{}
 func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("AncestryDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match 1", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -257,10 +287,31 @@ type ftDNAProvider struct{}
 func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
-	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	slog.Info("FTDNA: fetching DNA data (mock mode)")
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match 1", "shared_cm": 120, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"]; ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"]; ok {
+			extra["confidence"] = val
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }


### PR DESCRIPTION
This PR addresses task `T-4.1.2 — Implement DNA provider API stubs (Stubbed)`.

### What
- Updated `AncestryDNA` and `FTDNA` providers in `services/integration_service/internal/service/integration_service.go` to return functional mock data containing `shared_cm` and `confidence` properties, similar to the existing `23andMe` stub.
- Refactored `MapToInternal` for `23andMe`, `AncestryDNA`, and `FTDNA` providers to safely parse raw map data. It now uses idiomatic Go map key checks (`if val, ok := map["key"]; ok`) rather than unsafe direct access that could lead to nil value pollution.
- Updated the status of all three DNA providers to `"AVAILABLE"` in `ListProviders`.
- Marked `T-4.1.2` as complete in `docs/todo.md`.

### Testing
- Ran `go build ./...` and `go test ./...` in `services/integration_service` (tests passed, no compilation errors).
- Ran global test loop (`go test ./... -short` across all services) to verify no regressions were introduced.

---
*PR created automatically by Jules for task [14543335655780397048](https://jules.google.com/task/14543335655780397048) started by @chifamba*