### PR TITLE
feat: implement functional mock data for DNA provider stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -139,14 +139,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"access_token"}
+			info.Status = "AVAILABLE"
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"api_key"}
+			info.Status = "AVAILABLE"
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"kit_number", "password"}
+			info.Status = "AVAILABLE"
 		}
 
 		providers = append(providers, info)
@@ -184,12 +187,23 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		rec := InternalRecord{Type: "PERSON"}
+		if v, ok := raw["given_name"]; ok {
+			if s, ok := v.(string); ok {
+				rec.GivenName = s
+			}
+		}
+		if v, ok := raw["surname"]; ok {
+			if s, ok := v.(string); ok {
+				rec.Surname = s
+			}
+		}
+		if v, ok := raw["birth_date"]; ok {
+			if s, ok := v.(string); ok {
+				rec.BirthDate = s
+			}
+		}
+		records = append(records, rec)
 	}
 	return records, nil
 }
@@ -225,13 +239,19 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok {
+			extra["dna_match_name"] = name
+		}
+		if cm, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = cm
+		}
+		if conf, ok := raw["confidence"]; ok {
+			extra["confidence"] = conf
+		}
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +264,32 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok {
+			extra["dna_match_name"] = name
+		}
+		if cm, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = cm
+		}
+		if conf, ok := raw["confidence"]; ok {
+			extra["confidence"] = conf
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +299,30 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok {
+			extra["dna_match_name"] = name
+		}
+		if cm, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = cm
+		}
+		if conf, ok := raw["confidence"]; ok {
+			extra["confidence"] = conf
+		}
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }


### PR DESCRIPTION
This PR implements functional mock data for the remaining DNA provider integration stubs (AncestryDNA and FTDNA) to fulfill task T-4.1.2. It also enhances the robustness of existing provider parsing by replacing unsafe `fmt.Sprint` map extractions with explicit key existence and type assertions, preventing `"<nil>"` strings or panics. Finally, the provider statuses are updated to "AVAILABLE", and the `todo.md` is updated.

Critical decision: The DNA external providers lack public/open endpoints for live integration testing, so we implemented robust, structural mock data rather than attempting to hit hallucinated endpoints. This fulfills the 'implement API stubs' requirement safely.

---
*PR created automatically by Jules for task [8516609447764060428](https://jules.google.com/task/8516609447764060428) started by @chifamba*