### PR TITLE
feat(integration): implement DNA provider stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -244,11 +247,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +276,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 120, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	expectedStatuses := map[string]string{
+		"FamilySearch": "STUB",
+		"Ancestry":     "STUB",
+		"23andMe":      "AVAILABLE",
+		"AncestryDNA":  "AVAILABLE",
+		"FTDNA":        "AVAILABLE",
+	}
+
+	if len(providers) != 5 {
+		t.Fatalf("expected 5 providers, got %d", len(providers))
+	}
+
+	for _, p := range providers {
+		expectedStatus, ok := expectedStatuses[p.Name]
+		if !ok {
+			t.Errorf("unexpected provider: %s", p.Name)
+			continue
+		}
+		if p.Status != expectedStatus {
+			t.Errorf("expected status %s for provider %s, got %s", expectedStatus, p.Name, p.Status)
+		}
+	}
+}
+
+func TestSyncExternalData(t *testing.T) {
+	svc := NewIntegrationService()
+	ctx := context.Background()
+
+	tests := []struct {
+		providerName string
+		expectCount  int
+		expectError  bool
+	}{
+		{"23andMe", 1, false},
+		{"AncestryDNA", 1, false},
+		{"FTDNA", 1, false},
+		{"FamilySearch", 1, false},
+		{"Ancestry", 0, false},
+		{"Unknown", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.providerName, func(t *testing.T) {
+			result, err := svc.SyncExternalData(ctx, tc.providerName, nil)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error for provider %s, got nil", tc.providerName)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for provider %s: %v", tc.providerName, err)
+			}
+			if result.RecordsMapped != tc.expectCount {
+				t.Errorf("expected %d records mapped for provider %s, got %d", tc.expectCount, tc.providerName, result.RecordsMapped)
+			}
+			if result.Provider != tc.providerName {
+				t.Errorf("expected result provider %s, got %s", tc.providerName, result.Provider)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What:**
Implemented the missing DNA provider stubs for `AncestryDNA` and `FTDNA` inside `services/integration_service/internal/service/integration_service.go`, so they now return functional mock data (`ProviderData`) and map it appropriately using `MapToInternal`. Also marked the status of DNA providers as `AVAILABLE` instead of `STUB`.

**Why:**
To complete task `T-4.1.2` from the project `todo.md` file regarding DNA integration stubs. The project uses mock data for external API integrations when there's no reliable or public endpoint available, acting as an active data layer for downstream testing.

**How:**
- Replaced the empty responses in `FetchData` for `AncestryDNA` and `FTDNA` with realistic single-record stub data.
- Filled in `MapToInternal` to unpack the data and create `InternalRecord` arrays.
- Switched the returned value in the `ListProviders` logic for DNA integrations.
- Created unit tests verifying statuses and `SyncExternalData` handling.

---
*PR created automatically by Jules for task [16006140916166002574](https://jules.google.com/task/16006140916166002574) started by @chifamba*