### PR TITLE
feat: Implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -201,11 +201,28 @@ func (p *ancestryProvider) Name() string { return "Ancestry" }
 
 func (p *ancestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("Ancestry: fetching data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "person", "given_name": "Ancestry", "surname": "Mock", "birth_date": "1910"},
+		},
+	}, nil
 }
 
 func (p *ancestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		givenName, _ := raw["given_name"].(string)
+		surname, _ := raw["surname"].(string)
+		birthDate, _ := raw["birth_date"].(string)
+
+		records = append(records, InternalRecord{
+			Type:      "PERSON",
+			GivenName: givenName,
+			Surname:   surname,
+			BirthDate: birthDate,
+		})
+	}
+	return records, nil
 }
 
 // dna23AndMeProvider is a stub for 23andMe DNA provider.
@@ -244,11 +261,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +290,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100, "confidence": 0.75},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,83 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chifamba/dzinza/services/integration_service/internal/service"
+)
+
+func TestFamilySearchProvider(t *testing.T) {
+	svc := service.NewIntegrationService()
+	result, err := svc.SyncExternalData(context.Background(), "FamilySearch", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RecordsFetched != 1 {
+		t.Errorf("expected 1 record fetched, got %d", result.RecordsFetched)
+	}
+	if result.RecordsMapped != 1 {
+		t.Errorf("expected 1 record mapped, got %d", result.RecordsMapped)
+	}
+}
+
+func TestAncestryProvider(t *testing.T) {
+	svc := service.NewIntegrationService()
+	result, err := svc.SyncExternalData(context.Background(), "Ancestry", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RecordsFetched != 1 {
+		t.Errorf("expected 1 record fetched, got %d", result.RecordsFetched)
+	}
+	if result.RecordsMapped != 1 {
+		t.Errorf("expected 1 record mapped, got %d", result.RecordsMapped)
+	}
+}
+
+func Test23AndMeProvider(t *testing.T) {
+	svc := service.NewIntegrationService()
+	result, err := svc.SyncExternalData(context.Background(), "23andMe", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RecordsFetched != 1 {
+		t.Errorf("expected 1 record fetched, got %d", result.RecordsFetched)
+	}
+	if result.RecordsMapped != 1 {
+		t.Errorf("expected 1 record mapped, got %d", result.RecordsMapped)
+	}
+}
+
+func TestAncestryDNAProvider(t *testing.T) {
+	svc := service.NewIntegrationService()
+	result, err := svc.SyncExternalData(context.Background(), "AncestryDNA", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RecordsFetched != 1 {
+		t.Errorf("expected 1 record fetched, got %d", result.RecordsFetched)
+	}
+	if result.RecordsMapped != 1 {
+		t.Errorf("expected 1 record mapped, got %d", result.RecordsMapped)
+	}
+}
+
+func TestFTDNAProvider(t *testing.T) {
+	svc := service.NewIntegrationService()
+	result, err := svc.SyncExternalData(context.Background(), "FTDNA", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RecordsFetched != 1 {
+		t.Errorf("expected 1 record fetched, got %d", result.RecordsFetched)
+	}
+	if result.RecordsMapped != 1 {
+		t.Errorf("expected 1 record mapped, got %d", result.RecordsMapped)
+	}
+}


### PR DESCRIPTION
This PR implements the DNA provider API stubs requested in task T-4.1.2 of the `docs/todo.md` specification.

### What
- Populated `ancestryProvider` with mock Ancestry.com genealogy integration data.
- Populated `dnaAncestryProvider` with mock AncestryDNA match data.
- Populated `ftDNAProvider` with mock FamilyTreeDNA match data.
- Safely mapped fetched map values to `InternalRecord` by avoiding panicking type assertions.
- Updated `docs/todo.md` marking T-4.1.2 complete.

### Coverage
- Added `services/integration_service/internal/service/integration_service_test.go`.
- Validated records are successfully fetched and mapped for all providers.

### Result
External integration sync operations for all providers now return functional mock data mapped safely, avoiding missing API implementations while preventing regression panics.

---
*PR created automatically by Jules for task [7763846898595306678](https://jules.google.com/task/7763846898595306678) started by @chifamba*