### PR TITLE
feat: Implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -225,13 +228,20 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok {
+			extra["dna_match_name"] = name
+		}
+		if sharedCM, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = sharedCM
+		}
+		if confidence, ok := raw["confidence"]; ok {
+			extra["confidence"] = confidence
+		}
+
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +254,33 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "DNA Match", "shared_cm": 150, "confidence": 0.85},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok {
+			extra["dna_match_name"] = name
+		}
+		if sharedCM, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = sharedCM
+		}
+		if confidence, ok := raw["confidence"]; ok {
+			extra["confidence"] = confidence
+		}
+
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +290,31 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "DNA Match", "shared_cm": 150, "confidence": 0.85},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if name, ok := raw["name"]; ok {
+			extra["dna_match_name"] = name
+		}
+		if sharedCM, ok := raw["shared_cm"]; ok {
+			extra["shared_cm"] = sharedCM
+		}
+		if confidence, ok := raw["confidence"]; ok {
+			extra["confidence"] = confidence
+		}
+
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationService_ListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	assert.NotEmpty(t, providers)
+
+	for _, p := range providers {
+		switch p.Name {
+		case "23andMe", "AncestryDNA", "FTDNA":
+			assert.Equal(t, "AVAILABLE", p.Status, "Expected %s to have status AVAILABLE", p.Name)
+			assert.Equal(t, "DNA", p.Category, "Expected %s to be in DNA category", p.Name)
+		default:
+			assert.Equal(t, "STUB", p.Status, "Expected %s to have status STUB", p.Name)
+		}
+	}
+}
+
+func TestDNAProviders_FetchAndMap(t *testing.T) {
+	svc := NewIntegrationService()
+
+	providersToTest := []string{"23andme", "ancestrydna", "ftdna"}
+
+	for _, providerName := range providersToTest {
+		t.Run(providerName, func(t *testing.T) {
+			result, err := svc.SyncExternalData(context.Background(), providerName, nil)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.Equal(t, 1, result.RecordsFetched, "Expected 1 record fetched for %s", providerName)
+			assert.Equal(t, 1, result.RecordsMapped, "Expected 1 record mapped for %s", providerName)
+
+			// Get the provider directly to test MapToInternal output in detail
+			provider, ok := svc.(*integrationService).providers[providerName]
+			require.True(t, ok)
+
+			data, err := provider.FetchData(context.Background(), nil)
+			require.NoError(t, err)
+			require.NotNil(t, data)
+			require.Len(t, data.Records, 1)
+
+			assert.Equal(t, "dna_match", data.Records[0]["type"])
+			assert.Equal(t, "DNA Match", data.Records[0]["name"])
+			assert.Equal(t, 150, data.Records[0]["shared_cm"])
+			assert.Equal(t, 0.85, data.Records[0]["confidence"])
+
+			internalRecords, err := provider.MapToInternal(data)
+			require.NoError(t, err)
+			require.Len(t, internalRecords, 1)
+
+			record := internalRecords[0]
+			assert.Equal(t, "PERSON", record.Type)
+			require.NotNil(t, record.Extra)
+
+			assert.Equal(t, "DNA Match", record.Extra["dna_match_name"])
+			assert.Equal(t, 150, record.Extra["shared_cm"])
+			assert.Equal(t, 0.85, record.Extra["confidence"])
+		})
+	}
+}


### PR DESCRIPTION
Resolves task **T-4.1.2** from `todo.md` to implement DNA provider API stubs.
- Updated `integration_service.go` to provide safe JSON-style mock responses for `FetchData` and safely extract `dna_match_name`, `shared_cm`, and `confidence` fields using `ok` checks in `MapToInternal`.
- Updated `integrationService.ListProviders` to properly report `"AVAILABLE"` status for DNA category integrations.
- Created robust unit tests inside `integration_service_test.go` to verify `FetchData`, `MapToInternal`, and `ListProviders` return expected values without panics.
- Updated `todo.md` progress tracker.

---
*PR created automatically by Jules for task [8190423311119465348](https://jules.google.com/task/8190423311119465348) started by @chifamba*