### PR TITLE
feat: implement DNA provider API stubs with functional mock data

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -127,6 +127,11 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		}
 
 		switch p.Name() {
+		case "23andMe", "AncestryDNA", "FTDNA":
+			info.Status = "AVAILABLE"
+		}
+
+		switch p.Name() {
 		case "FamilySearch":
 			info.Description = "FamilySearch.org genealogy data integration"
 			info.Category = "GENEALOGY"
@@ -244,11 +249,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +278,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100, "confidence": 0.75},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }


### PR DESCRIPTION
**What:**
Implemented functional mock data for DNA provider stubs (`AncestryDNA` and `FTDNA`) within the `integration_service`. This fulfills the requirement specified in `docs/todo.md` under task `T-4.1.2`.

**Coverage:**
- Refactored `dnaAncestryProvider` and `ftDNAProvider` methods `FetchData` and `MapToInternal` to return mock data arrays consistent with the existing `dna23AndMeProvider`.
- Modified the status of these DNA providers to "AVAILABLE" in the `ListProviders` return output.
- Checked off task `T-4.1.2` in `docs/todo.md`.

**Result:**
The `integration_service` now serves functional mock data for DNA provider integrations, avoiding HTTP hallucinations and satisfying the advanced features plan requirement. All local tests run successfully.

---
*PR created automatically by Jules for task [9091281466957248769](https://jules.google.com/task/9091281466957248769) started by @chifamba*