### PR TITLE
feat: implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -244,11 +247,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "AncestryDNA Match", "shared_cm": 120, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +276,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 90, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIntegrationService_ListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	expectedStatuses := map[string]string{
+		"23andMe":      "AVAILABLE",
+		"AncestryDNA":  "AVAILABLE",
+		"FTDNA":        "AVAILABLE",
+		"FamilySearch": "STUB",
+		"Ancestry":     "STUB",
+	}
+
+	for _, p := range providers {
+		expected, ok := expectedStatuses[p.Name]
+		if !ok {
+			t.Errorf("Unexpected provider in ListProviders: %s", p.Name)
+			continue
+		}
+
+		if p.Status != expected {
+			t.Errorf("Provider %s status is %s, expected %s", p.Name, p.Status, expected)
+		}
+	}
+}
+
+func TestDnaAncestryProvider_FetchAndMap(t *testing.T) {
+	provider := &dnaAncestryProvider{}
+	ctx := context.Background()
+
+	data, err := provider.FetchData(ctx, nil)
+	if err != nil {
+		t.Fatalf("FetchData returned error: %v", err)
+	}
+
+	if len(data.Records) == 0 {
+		t.Fatalf("FetchData returned empty records")
+	}
+
+	records, err := provider.MapToInternal(data)
+	if err != nil {
+		t.Fatalf("MapToInternal returned error: %v", err)
+	}
+
+	if len(records) != len(data.Records) {
+		t.Errorf("Expected %d mapped records, got %d", len(data.Records), len(records))
+	}
+
+	firstRecord := records[0]
+	if firstRecord.Type != "PERSON" {
+		t.Errorf("Expected mapped record type 'PERSON', got '%s'", firstRecord.Type)
+	}
+
+	matchName, ok := firstRecord.Extra["dna_match_name"]
+	if !ok || matchName != "AncestryDNA Match" {
+		t.Errorf("Expected dna_match_name 'AncestryDNA Match', got %v", matchName)
+	}
+}
+
+func TestFtDNAProvider_FetchAndMap(t *testing.T) {
+	provider := &ftDNAProvider{}
+	ctx := context.Background()
+
+	data, err := provider.FetchData(ctx, nil)
+	if err != nil {
+		t.Fatalf("FetchData returned error: %v", err)
+	}
+
+	if len(data.Records) == 0 {
+		t.Fatalf("FetchData returned empty records")
+	}
+
+	records, err := provider.MapToInternal(data)
+	if err != nil {
+		t.Fatalf("MapToInternal returned error: %v", err)
+	}
+
+	if len(records) != len(data.Records) {
+		t.Errorf("Expected %d mapped records, got %d", len(data.Records), len(records))
+	}
+
+	firstRecord := records[0]
+	if firstRecord.Type != "PERSON" {
+		t.Errorf("Expected mapped record type 'PERSON', got '%s'", firstRecord.Type)
+	}
+
+	matchName, ok := firstRecord.Extra["dna_match_name"]
+	if !ok || matchName != "FTDNA Match" {
+		t.Errorf("Expected dna_match_name 'FTDNA Match', got %v", matchName)
+	}
+}


### PR DESCRIPTION
Implemented DNA provider API stubs (task T-4.1.2) for `AncestryDNA` and `FTDNA` by updating them to return functional mock records. Also correctly mapped those records to internal Dzinza structs, marked their statuses as `AVAILABLE`, added unit testing, and updated `todo.md`.

---
*PR created automatically by Jules for task [3644212286073598851](https://jules.google.com/task/3644212286073598851) started by @chifamba*