### PR TITLE
feat: implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -139,14 +139,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"access_token"}
+			info.Status = "AVAILABLE"
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"api_key"}
+			info.Status = "AVAILABLE"
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"kit_number", "password"}
+			info.Status = "AVAILABLE"
 		}
 
 		providers = append(providers, info)
@@ -184,12 +187,17 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		record := InternalRecord{Type: "PERSON"}
+		if val, ok := raw["given_name"].(string); ok {
+			record.GivenName = val
+		}
+		if val, ok := raw["surname"].(string); ok {
+			record.Surname = val
+		}
+		if val, ok := raw["birth_date"].(string); ok {
+			record.BirthDate = val
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }
@@ -244,11 +252,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "AncestryDNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +281,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,63 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chifamba/dzinza/services/integration_service/internal/service"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegrationService_ListProviders(t *testing.T) {
+	svc := service.NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	assert.NotEmpty(t, providers)
+
+	providerMap := make(map[string]service.ProviderInfo)
+	for _, p := range providers {
+		providerMap[p.Name] = p
+	}
+
+	tests := []struct {
+		name           string
+		expectedStatus string
+	}{
+		{"23andMe", "AVAILABLE"},
+		{"AncestryDNA", "AVAILABLE"},
+		{"FTDNA", "AVAILABLE"},
+		{"Ancestry", "STUB"},
+		{"FamilySearch", "STUB"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, exists := providerMap[tc.name]
+			assert.True(t, exists, "provider should exist")
+			assert.Equal(t, tc.expectedStatus, p.Status, "status should match")
+		})
+	}
+}
+
+func TestIntegrationService_SyncExternalData_DNA(t *testing.T) {
+	svc := service.NewIntegrationService()
+
+	tests := []struct {
+		providerName string
+	}{
+		{providerName: "23andMe"},
+		{providerName: "AncestryDNA"},
+		{providerName: "FTDNA"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.providerName, func(t *testing.T) {
+			res, err := svc.SyncExternalData(context.Background(), tc.providerName, nil)
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
+			assert.Equal(t, tc.providerName, res.Provider)
+			assert.Equal(t, 1, res.RecordsFetched)
+			assert.Equal(t, 1, res.RecordsMapped)
+		})
+	}
+}


### PR DESCRIPTION
Implemented functional mock data and proper mapping for DNA provider API stubs (AncestryDNA and FTDNA) to complete task `T-4.1.2`. Added comprehensive tests. Fixed an issue with `familySearchProvider`'s `MapToInternal` that could introduce `"<nil>"` strings by properly asserting types.

---
*PR created automatically by Jules for task [8427824723282174582](https://jules.google.com/task/8427824723282174582) started by @chifamba*