### PR TITLE
✨ feat(integration): Implement DNA provider API functional stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -244,11 +247,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +276,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100, "confidence": 0.75},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	expectedStatuses := map[string]string{
+		"23andMe":      "AVAILABLE",
+		"AncestryDNA":  "AVAILABLE",
+		"FTDNA":        "AVAILABLE",
+		"FamilySearch": "STUB",
+		"Ancestry":     "STUB",
+	}
+
+	foundMap := make(map[string]bool)
+
+	for _, p := range providers {
+		expectedStatus, ok := expectedStatuses[p.Name]
+		if ok {
+			foundMap[p.Name] = true
+			if p.Status != expectedStatus {
+				t.Errorf("Expected status for %s to be %s, but got %s", p.Name, expectedStatus, p.Status)
+			}
+		}
+	}
+
+	for name := range expectedStatuses {
+		if !foundMap[name] {
+			t.Errorf("Expected provider %s not found in ListProviders output", name)
+		}
+	}
+}
+
+func TestDNAProviders_FetchAndMap(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     ExternalProvider
+		expectedName string
+		expectedCM   float64
+		expectedConf float64
+	}{
+		{
+			name:         "23andMe",
+			provider:     &dna23AndMeProvider{},
+			expectedName: "DNA Match",
+			expectedCM:   150.0,
+			expectedConf: 0.85,
+		},
+		{
+			name:         "AncestryDNA",
+			provider:     &dnaAncestryProvider{},
+			expectedName: "Ancestry Match",
+			expectedCM:   200.0,
+			expectedConf: 0.90,
+		},
+		{
+			name:         "FTDNA",
+			provider:     &ftDNAProvider{},
+			expectedName: "FTDNA Match",
+			expectedCM:   100.0,
+			expectedConf: 0.75,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.provider.FetchData(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("FetchData returned error: %v", err)
+			}
+
+			if len(data.Records) != 1 {
+				t.Fatalf("Expected 1 record, got %d", len(data.Records))
+			}
+
+			internalRecords, err := tt.provider.MapToInternal(data)
+			if err != nil {
+				t.Fatalf("MapToInternal returned error: %v", err)
+			}
+
+			if len(internalRecords) != 1 {
+				t.Fatalf("Expected 1 internal record, got %d", len(internalRecords))
+			}
+
+			rec := internalRecords[0]
+			if rec.Type != "PERSON" {
+				t.Errorf("Expected type PERSON, got %s", rec.Type)
+			}
+
+			if rec.Extra == nil {
+				t.Fatalf("Expected non-nil Extra map")
+			}
+
+			matchName, ok := rec.Extra["dna_match_name"].(string)
+			if !ok || matchName != tt.expectedName {
+				t.Errorf("Expected dna_match_name %s, got %v", tt.expectedName, rec.Extra["dna_match_name"])
+			}
+
+			// In JSON parsing without strict schema, numbers might be parsed as float64 or int.
+			// The mock data provides int/float directly.
+			// Let's assert based on float64 or int conversion
+			assertNum(t, rec.Extra["shared_cm"], tt.expectedCM)
+			assertNum(t, rec.Extra["confidence"], tt.expectedConf)
+		})
+	}
+}
+
+func assertNum(t *testing.T, actual interface{}, expected float64) {
+	switch v := actual.(type) {
+	case float64:
+		if v != expected {
+			t.Errorf("Expected %f, got %f", expected, v)
+		}
+	case int:
+		if float64(v) != expected {
+			t.Errorf("Expected %f, got %d", expected, v)
+		}
+	default:
+		t.Errorf("Unexpected type for number: %T", actual)
+	}
+}


### PR DESCRIPTION
**What:** 
Implemented functional mock data and proper mapping for DNA providers (AncestryDNA and FTDNA) in the `integration_service` to match the existing `23andMe` implementation. Also marked all DNA providers as `AVAILABLE`.

**Coverage:**
- Added test file `services/integration_service/internal/service/integration_service_test.go`.
- Includes table-driven tests for `ListProviders` to ensure accurate provider statuses.
- Includes table-driven tests for `FetchData` and `MapToInternal` for each DNA provider to verify fields are properly mapped without panics.

**Result:**
The integration service now successfully returns and maps functional mock data for DNA records instead of empty stubs, completing task `T-4.1.2`. All tests pass.

---
*PR created automatically by Jules for task [2742303087509144807](https://jules.google.com/task/2742303087509144807) started by @chifamba*