### PR TITLE
[Enhancement] Implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -139,14 +139,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"access_token"}
+			info.Status = "AVAILABLE"
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"api_key"}
+			info.Status = "AVAILABLE"
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"kit_number", "password"}
+			info.Status = "AVAILABLE"
 		}
 
 		providers = append(providers, info)
@@ -244,11 +247,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +276,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 180, "confidence": 0.88},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	expectedStatuses := map[string]string{
+		"23andme":     "AVAILABLE",
+		"ancestrydna": "AVAILABLE",
+		"ftdna":       "AVAILABLE",
+	}
+
+	for _, p := range providers {
+		key := strings.ToLower(p.Name)
+		if expectedStatus, ok := expectedStatuses[key]; ok {
+			if p.Status != expectedStatus {
+				t.Errorf("Provider %s: expected status %s, got %s", p.Name, expectedStatus, p.Status)
+			}
+		}
+	}
+}
+
+func TestSyncExternalData(t *testing.T) {
+	svc := NewIntegrationService()
+
+	providersToTest := []string{"23andMe", "AncestryDNA", "FTDNA"}
+
+	for _, providerName := range providersToTest {
+		t.Run(providerName, func(t *testing.T) {
+			result, err := svc.SyncExternalData(context.Background(), providerName, nil)
+			if err != nil {
+				t.Fatalf("SyncExternalData failed for %s: %v", providerName, err)
+			}
+
+			if result.RecordsFetched != 1 {
+				t.Errorf("Expected 1 record fetched for %s, got %d", providerName, result.RecordsFetched)
+			}
+
+			if result.RecordsMapped != 1 {
+				t.Errorf("Expected 1 record mapped for %s, got %d", providerName, result.RecordsMapped)
+			}
+		})
+	}
+}
+
+func TestMapToInternal(t *testing.T) {
+	// Directly test the providers' MapToInternal to verify Extra map properties
+	svc := NewIntegrationService()
+	isvc := svc.(*integrationService)
+
+	providersToTest := []string{"23andMe", "AncestryDNA", "FTDNA"}
+
+	for _, providerName := range providersToTest {
+		t.Run(providerName+"_MapToInternal", func(t *testing.T) {
+			p, ok := isvc.providers[strings.ToLower(providerName)]
+			if !ok {
+				t.Fatalf("Provider %s not found", providerName)
+			}
+
+			data, err := p.FetchData(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("FetchData failed for %s: %v", providerName, err)
+			}
+
+			records, err := p.MapToInternal(data)
+			if err != nil {
+				t.Fatalf("MapToInternal failed for %s: %v", providerName, err)
+			}
+
+			if len(records) != 1 {
+				t.Fatalf("Expected 1 record mapped for %s, got %d", providerName, len(records))
+			}
+
+			rec := records[0]
+			if rec.Type != "PERSON" {
+				t.Errorf("Expected record type PERSON for %s, got %s", providerName, rec.Type)
+			}
+
+			if rec.Extra == nil {
+				t.Fatalf("Expected non-nil Extra map for %s", providerName)
+			}
+
+			expectedKeys := []string{"dna_match_name", "shared_cm", "confidence"}
+			for _, key := range expectedKeys {
+				if _, ok := rec.Extra[key]; !ok {
+					t.Errorf("Expected Extra map to contain key %s for %s", key, providerName)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
What:
- Implement DNA provider API stubs (FTDNA, AncestryDNA, 23andMe) with mock data and mapping
- Add unit tests for `integration_service` to test provider logic
- Mark task T-4.1.2 as complete

Coverage:
- Tests check if the providers map the data properly and if the list API correctly exposes their config

Result:
- Integration service supports fake API integration for testing
- todo.md reflects current task completion

---
*PR created automatically by Jules for task [13531944462717605365](https://jules.google.com/task/13531944462717605365) started by @chifamba*