### PR TITLE
feat: Implement DNA provider stubs with functional mock data

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -122,8 +122,13 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 	var providers []ProviderInfo
 	for _, p := range s.providers {
 		info := ProviderInfo{
-			Name:   p.Name(),
-			Status: "STUB",
+			Name: p.Name(),
+		}
+
+		if p.Name() == "23andMe" || p.Name() == "AncestryDNA" || p.Name() == "FTDNA" {
+			info.Status = "AVAILABLE"
+		} else {
+			info.Status = "STUB"
 		}
 
 		switch p.Name() {
@@ -184,12 +189,19 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		record := InternalRecord{
+			Type: "PERSON",
+		}
+		if val, ok := raw["given_name"].(string); ok {
+			record.GivenName = val
+		}
+		if val, ok := raw["surname"].(string); ok {
+			record.Surname = val
+		}
+		if val, ok := raw["birth_date"].(string); ok {
+			record.BirthDate = val
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }
@@ -225,13 +237,22 @@ func (p *dna23AndMeProvider) FetchData(ctx context.Context, config map[string]st
 func (p *dna23AndMeProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = val
+		} else if val, ok := raw["shared_cm"].(float64); ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"].(float64); ok {
+			extra["confidence"] = val
+		}
+
 		records = append(records, InternalRecord{
-			Type: "PERSON",
-			Extra: map[string]interface{}{
-				"dna_match_name": raw["name"],
-				"shared_cm":      raw["shared_cm"],
-				"confidence":     raw["confidence"],
-			},
+			Type:  "PERSON",
+			Extra: extra,
 		})
 	}
 	return records, nil
@@ -244,11 +265,35 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry DNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = val
+		} else if val, ok := raw["shared_cm"].(float64); ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"].(float64); ok {
+			extra["confidence"] = val
+		}
+
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +303,33 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100, "confidence": 0.80},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		extra := make(map[string]interface{})
+		if val, ok := raw["name"].(string); ok {
+			extra["dna_match_name"] = val
+		}
+		if val, ok := raw["shared_cm"].(int); ok {
+			extra["shared_cm"] = val
+		} else if val, ok := raw["shared_cm"].(float64); ok {
+			extra["shared_cm"] = val
+		}
+		if val, ok := raw["confidence"].(float64); ok {
+			extra["confidence"] = val
+		}
+
+		records = append(records, InternalRecord{
+			Type:  "PERSON",
+			Extra: extra,
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	if len(providers) != 5 {
+		t.Fatalf("expected 5 providers, got %d", len(providers))
+	}
+
+	providerStatusMap := make(map[string]string)
+	for _, p := range providers {
+		providerStatusMap[p.Name] = p.Status
+	}
+
+	availableProviders := []string{"23andMe", "AncestryDNA", "FTDNA"}
+	for _, name := range availableProviders {
+		if status := providerStatusMap[name]; status != "AVAILABLE" {
+			t.Errorf("expected provider %s to be AVAILABLE, got %s", name, status)
+		}
+	}
+
+	stubProviders := []string{"FamilySearch", "Ancestry"}
+	for _, name := range stubProviders {
+		if status := providerStatusMap[name]; status != "STUB" {
+			t.Errorf("expected provider %s to be STUB, got %s", name, status)
+		}
+	}
+}
+
+func TestSyncExternalData_DNAProviders(t *testing.T) {
+	svc := NewIntegrationService()
+
+	testCases := []struct {
+		providerName string
+		expectedName string
+		expectedCM   float64
+	}{
+		{"23andme", "DNA Match", 150.0},
+		{"ancestrydna", "Ancestry DNA Match", 200.0},
+		{"ftdna", "FTDNA Match", 100.0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.providerName, func(t *testing.T) {
+			result, err := svc.SyncExternalData(context.Background(), tc.providerName, nil)
+			if err != nil {
+				t.Fatalf("expected no error for %s, got %v", tc.providerName, err)
+			}
+
+			if result.RecordsFetched != 1 {
+				t.Errorf("expected 1 record fetched for %s, got %d", tc.providerName, result.RecordsFetched)
+			}
+			if result.RecordsMapped != 1 {
+				t.Errorf("expected 1 record mapped for %s, got %d", tc.providerName, result.RecordsMapped)
+			}
+			if strings.ToLower(result.Provider) != tc.providerName {
+				t.Errorf("expected provider %s, got %s", tc.providerName, result.Provider)
+			}
+
+			// Validate internal mapping logic
+			provider, ok := svc.(*integrationService).providers[tc.providerName]
+			if !ok {
+				t.Fatalf("expected provider %s to exist", tc.providerName)
+			}
+
+			data, _ := provider.FetchData(context.Background(), nil)
+			records, _ := provider.MapToInternal(data)
+
+			if len(records) != 1 {
+				t.Fatalf("expected 1 internal record, got %d", len(records))
+			}
+
+			record := records[0]
+			if record.Type != "PERSON" {
+				t.Errorf("expected Type PERSON, got %s", record.Type)
+			}
+
+			extra := record.Extra
+			if extra == nil {
+				t.Fatalf("expected Extra map, got nil")
+			}
+
+			if name, ok := extra["dna_match_name"].(string); !ok || name != tc.expectedName {
+				t.Errorf("expected dna_match_name %s, got %v", tc.expectedName, extra["dna_match_name"])
+			}
+
+			// Handle both int and float64 assertions since JSON unmarshalling or our mock can do both
+			var cm float64
+			switch v := extra["shared_cm"].(type) {
+			case int:
+				cm = float64(v)
+			case float64:
+				cm = v
+			default:
+				t.Fatalf("unexpected type for shared_cm: %T", v)
+			}
+
+			if cm != tc.expectedCM {
+				t.Errorf("expected shared_cm %f, got %f", tc.expectedCM, cm)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented functional mock API responses for external DNA providers (AncestryDNA and FTDNA), mirroring the existing structure for 23andMe to allow frontend and upstream services to test integrations. Improved robustness of mapping from mock maps by utilizing type assertions instead of `fmt.Sprint`. Added comprehensive unit tests and verified all codebase tests pass successfully. Task T-4.1.2 is officially closed in the `todo.md`.

---
*PR created automatically by Jules for task [829867469036598475](https://jules.google.com/task/829867469036598475) started by @chifamba*