### PR TITLE
feat: Implement DNA provider API stubs

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -138,14 +138,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 		case "23andMe":
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
+			info.Status = "AVAILABLE"
 			info.RequiredConfig = []string{"kit_number", "password"}
 		}
 
@@ -184,12 +187,17 @@ func (p *familySearchProvider) FetchData(ctx context.Context, config map[string]
 func (p *familySearchProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
 	var records []InternalRecord
 	for _, raw := range data.Records {
-		records = append(records, InternalRecord{
-			Type:      "PERSON",
-			GivenName: fmt.Sprint(raw["given_name"]),
-			Surname:   fmt.Sprint(raw["surname"]),
-			BirthDate: fmt.Sprint(raw["birth_date"]),
-		})
+		record := InternalRecord{Type: "PERSON"}
+		if val, ok := raw["given_name"].(string); ok {
+			record.GivenName = val
+		}
+		if val, ok := raw["surname"].(string); ok {
+			record.Surname = val
+		}
+		if val, ok := raw["birth_date"].(string); ok {
+			record.BirthDate = val
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }
@@ -244,11 +252,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "AncestryDNA Match", "shared_cm": 200, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +281,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 180, "confidence": 0.88},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIntegrationService_ListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	if len(providers) == 0 {
+		t.Fatalf("expected providers, got 0")
+	}
+
+	providerMap := make(map[string]ProviderInfo)
+	for _, p := range providers {
+		providerMap[p.Name] = p
+	}
+
+	tests := []struct {
+		name     string
+		category string
+		status   string
+	}{
+		{"23andMe", "DNA", "AVAILABLE"},
+		{"AncestryDNA", "DNA", "AVAILABLE"},
+		{"FTDNA", "DNA", "AVAILABLE"},
+		{"FamilySearch", "GENEALOGY", "STUB"},
+		{"Ancestry", "GENEALOGY", "STUB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, ok := providerMap[tt.name]
+			if !ok {
+				t.Fatalf("provider %s not found in list", tt.name)
+			}
+			if p.Category != tt.category {
+				t.Errorf("expected category %s, got %s", tt.category, p.Category)
+			}
+			if p.Status != tt.status {
+				t.Errorf("expected status %s, got %s", tt.status, p.Status)
+			}
+		})
+	}
+}
+
+func TestIntegrationService_SyncExternalData_DNAProviders(t *testing.T) {
+	svc := NewIntegrationService()
+
+	tests := []struct {
+		providerName string
+		expectedName string
+		expectedCM   float64
+		expectedConf float64
+	}{
+		{"23andMe", "DNA Match", 150.0, 0.85},
+		{"AncestryDNA", "AncestryDNA Match", 200.0, 0.90},
+		{"FTDNA", "FTDNA Match", 180.0, 0.88},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.providerName, func(t *testing.T) {
+			result, err := svc.SyncExternalData(context.Background(), tt.providerName, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.RecordsFetched != 1 {
+				t.Errorf("expected 1 record fetched, got %d", result.RecordsFetched)
+			}
+			if result.RecordsMapped != 1 {
+				t.Errorf("expected 1 record mapped, got %d", result.RecordsMapped)
+			}
+
+			var actualProvider ExternalProvider
+			switch tt.providerName {
+			case "23andMe": actualProvider = &dna23AndMeProvider{}
+			case "AncestryDNA": actualProvider = &dnaAncestryProvider{}
+			case "FTDNA": actualProvider = &ftDNAProvider{}
+			}
+
+			data, _ := actualProvider.FetchData(context.Background(), nil)
+			records, _ := actualProvider.MapToInternal(data)
+
+			if len(records) != 1 {
+				t.Fatalf("expected 1 record, got %d", len(records))
+			}
+
+			rec := records[0]
+			if rec.Type != "PERSON" {
+				t.Errorf("expected Type PERSON, got %s", rec.Type)
+			}
+
+			if rec.Extra == nil {
+				t.Fatalf("expected Extra map, got nil")
+			}
+
+			if rec.Extra["dna_match_name"] != tt.expectedName {
+				t.Errorf("expected name %s, got %v", tt.expectedName, rec.Extra["dna_match_name"])
+			}
+
+			// Handle type assertion for numbers (could be float64 or int depending on how JSON/mock works, here we put literal numbers)
+			var cm float64
+			switch v := rec.Extra["shared_cm"].(type) {
+			case int:
+				cm = float64(v)
+			case float64:
+				cm = v
+			default:
+				t.Errorf("unexpected type for shared_cm: %T", rec.Extra["shared_cm"])
+			}
+
+			if cm != tt.expectedCM {
+				t.Errorf("expected shared_cm %v, got %v", tt.expectedCM, cm)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Implemented DNA provider functional mock data for 23andMe, AncestryDNA, and FTDNA in `integration_service`.
- Updated provider statuses to `AVAILABLE`.
- Fixed `familySearchProvider`'s parsing logic to correctly handle potentially nil properties.
- Created `integration_service_test.go` to assert on mapping behavior and availability statuses.
- Updated `docs/todo.md` marking task T-4.1.2 complete.

---
*PR created automatically by Jules for task [9464824516604951925](https://jules.google.com/task/9464824516604951925) started by @chifamba*