### PR TITLE
feat: implement dna provider stubs for integration service

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -234,7 +234,7 @@
 ### 4.1 DNA Integration
 
 - [x] **T-4.1.1** — Implement DNA data models
-- [ ] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
+- [x] **T-4.1.2** — Implement DNA provider API stubs (Stubbed)
 
 ### 4.2 AI Content Moderation
 

--- a/services/integration_service/go.mod
+++ b/services/integration_service/go.mod
@@ -7,12 +7,14 @@ replace github.com/chifamba/dzinza/services/pkg => ../pkg
 require (
 	github.com/chifamba/dzinza/services/pkg v0.0.0-00010101000000-000000000000
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/integration_service/go.sum
+++ b/services/integration_service/go.sum
@@ -82,6 +82,7 @@ golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/integration_service/internal/service/integration_service.go
+++ b/services/integration_service/internal/service/integration_service.go
@@ -136,14 +136,17 @@ func (s *integrationService) ListProviders(ctx context.Context) []ProviderInfo {
 			info.Category = "GENEALOGY"
 			info.RequiredConfig = []string{"api_key", "tree_id"}
 		case "23andMe":
+			info.Status = "AVAILABLE"
 			info.Description = "23andMe DNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"access_token"}
 		case "AncestryDNA":
+			info.Status = "AVAILABLE"
 			info.Description = "AncestryDNA match import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"api_key"}
 		case "FTDNA":
+			info.Status = "AVAILABLE"
 			info.Description = "FamilyTreeDNA data import"
 			info.Category = "DNA"
 			info.RequiredConfig = []string{"kit_number", "password"}
@@ -244,11 +247,26 @@ func (p *dnaAncestryProvider) Name() string { return "AncestryDNA" }
 
 func (p *dnaAncestryProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("AncestryDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "Ancestry Match", "shared_cm": 200.0, "confidence": 0.90},
+		},
+	}, nil
 }
 
 func (p *dnaAncestryProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }
 
 // ftDNAProvider is a stub for FamilyTreeDNA provider.
@@ -258,9 +276,24 @@ func (p *ftDNAProvider) Name() string { return "FTDNA" }
 
 func (p *ftDNAProvider) FetchData(ctx context.Context, config map[string]string) (*ProviderData, error) {
 	slog.Info("FTDNA: fetching DNA data (stub mode)")
-	return &ProviderData{Records: []map[string]interface{}{}}, nil
+	return &ProviderData{
+		Records: []map[string]interface{}{
+			{"type": "dna_match", "name": "FTDNA Match", "shared_cm": 100.0, "confidence": 0.75},
+		},
+	}, nil
 }
 
 func (p *ftDNAProvider) MapToInternal(data *ProviderData) ([]InternalRecord, error) {
-	return nil, nil
+	var records []InternalRecord
+	for _, raw := range data.Records {
+		records = append(records, InternalRecord{
+			Type: "PERSON",
+			Extra: map[string]interface{}{
+				"dna_match_name": raw["name"],
+				"shared_cm":      raw["shared_cm"],
+				"confidence":     raw["confidence"],
+			},
+		})
+	}
+	return records, nil
 }

--- a/services/integration_service/internal/service/integration_service_test.go
+++ b/services/integration_service/internal/service/integration_service_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListProviders(t *testing.T) {
+	svc := NewIntegrationService()
+	providers := svc.ListProviders(context.Background())
+
+	assert.GreaterOrEqual(t, len(providers), 5)
+
+	providerMap := make(map[string]ProviderInfo)
+	for _, p := range providers {
+		providerMap[p.Name] = p
+	}
+
+	for _, name := range []string{"23andMe", "AncestryDNA", "FTDNA"} {
+		p, ok := providerMap[name]
+		assert.True(t, ok, "Provider %s should exist", name)
+		assert.Equal(t, "AVAILABLE", p.Status, "Provider %s should be AVAILABLE", name)
+	}
+}
+
+func TestSyncExternalData_DNAProviders(t *testing.T) {
+	svc := NewIntegrationService()
+
+	testCases := []struct {
+		providerName string
+		expectExtra  map[string]interface{}
+	}{
+		{
+			providerName: "23andMe",
+			expectExtra: map[string]interface{}{
+				"dna_match_name": "DNA Match",
+				"shared_cm":      150,
+				"confidence":     float64(0.85),
+			},
+		},
+		{
+			providerName: "AncestryDNA",
+			expectExtra: map[string]interface{}{
+				"dna_match_name": "Ancestry Match",
+				"shared_cm":      float64(200),
+				"confidence":     float64(0.90),
+			},
+		},
+		{
+			providerName: "FTDNA",
+			expectExtra: map[string]interface{}{
+				"dna_match_name": "FTDNA Match",
+				"shared_cm":      float64(100),
+				"confidence":     float64(0.75),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.providerName, func(t *testing.T) {
+			res, err := svc.SyncExternalData(context.Background(), tc.providerName, map[string]string{})
+			assert.NoError(t, err)
+			assert.Equal(t, 1, res.RecordsFetched)
+			assert.Equal(t, 1, res.RecordsMapped)
+
+			provider := svc.(*integrationService).providers[strings.ToLower(tc.providerName)]
+			data, _ := provider.FetchData(context.Background(), nil)
+			records, _ := provider.MapToInternal(data)
+			assert.Equal(t, tc.expectExtra, records[0].Extra)
+		})
+	}
+}


### PR DESCRIPTION
Implemented functional mock data and `MapToInternal` for DNA provider stubs (`dnaAncestryProvider` and `ftDNAProvider`) in the `integration_service`. Marked them as "AVAILABLE" in `ListProviders`. Fixed broken tests and added missing tests. Updated the project tracker (`todo.md`).

---
*PR created automatically by Jules for task [3344228483515422731](https://jules.google.com/task/3344228483515422731) started by @chifamba*